### PR TITLE
restrict intake to version 1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ matplotlib
 numpy
 xarray
 dask>=2023.2.0
-intake[dataframe] # since intake 0.6.1 to_dask() doesn't work anymore without the [dataframe] specification due to a missing msgpack dependency
+intake[dataframe]<2.0.0 # since intake 0.6.1 to_dask() doesn't work anymore without the [dataframe] specification due to a missing msgpack dependency
 intake-xarray
 fsspec!=0.9.0 # 0.9.0 has a bug which leads to incomplete reads via HTTP
 requests


### PR DESCRIPTION
While intake 2 should become the default, currently there's an issue when loading zarr datasets from version 1 catalogs. As long as this issue persists, we probably can't migrate to intake 2 and thus have to wait a bit still.

The particular error is supposed to be fixed when intake 2.0.1 is released. We should reevaluate intake 2 at that point.
