### PR TITLE
Add streamlined data policy

### DIFF
--- a/orcestra_book/_toc.yml
+++ b/orcestra_book/_toc.yml
@@ -23,7 +23,7 @@ chapters:
 #- file: operation
 - file: data
   sections:
-    #- file: data_policy
+    - file: data_policy
     #- file: data_creation
     #- file: data_access
     - file: data_concept

--- a/orcestra_book/data_policy.md
+++ b/orcestra_book/data_policy.md
@@ -1,7 +1,11 @@
 # Data Policy
 
-ORCESTRA follows the open data policy established for NARVAL which  means that we do not intend to police the use of, or access to, the data. Instead we rely on the good will and scientific integrity of those interested in using the data to respect the efforts of those whose were responsible for its collection by adhering to the two guidelines below:
+ORCESTRA encourages free use and access to data without strict control. We trust in the integrity of the scientific community to honor the contributions of those who collected these data.
 
-Unlike in some other contexts the ORCESTRA data is made available through the individual efforts and particular funding of a number of independent research groups. Often the data that is collected represents the fruits of many years of effort to develop, certify and operate an instrument. This effort is often connected to individual research projects, and even PhD projects. For this reason, we consider it a matter of scientific integrity for users to respect the priority of those who collected the data, by coordinating your planned use with the instrument PIs (list will follow), and making an effort to explicitly and clearly acknowledge the origin of the data when it is presented to a broader community in the form of publications or presentations.
+The ORCESTRA data are a product of the collective efforts and funding of various independent research groups. It often represents years of work in developing, certifying, and operating instruments, often tied to specific research or Ph.D. projects. We ask users to respect the priority of the data collectors by coordinating use with the instrument Principal Investigators (PIs) and by clearly acknowledging the source of the data in any publications or presentations.
 
-For publications that include ORCESTRA data, include the following in your acknowledgements: The data used in this publication was gathered in the ORCESTRA field campaign and is made available through [insert name of the institute]. ORCESTRA is funded with support of the European Space Agency (ESA), the Max Planck Society (MPG), the German Research Foundation (DFG) and the German Aerospace Center (DLR).
+For publications using ORCESTRA data, please include this acknowledgement:
+
+> "The data used in this publication was collected during the ORCESTRA field campaign and is available through [insert institute name]. ORCESTRA is supported by the European Space Agency (ESA), the Max Planck Society (MPG), the German Research Foundation (DFG), and the German Aerospace Center (DLR)."
+
+This approach ensures the recognition and respect for the significant efforts behind the data collection while promoting its open and respectful use.

--- a/orcestra_book/data_policy.md
+++ b/orcestra_book/data_policy.md
@@ -6,6 +6,6 @@ The ORCESTRA data are a product of the collective efforts and funding of various
 
 For publications using ORCESTRA data, please include this acknowledgement:
 
-> "The data used in this publication was collected during the ORCESTRA field campaign and is available through [insert institute name]. ORCESTRA is supported by the European Space Agency (ESA), the Max Planck Society (MPG), the German Research Foundation (DFG), and the German Aerospace Center (DLR)."
+> "The data used in this publication was collected during the ORCESTRA field campaign and is available through [insert institute name]. ORCESTRA is supported by the European Space Agency (ESA), the Max Planck Society (MPG), the German Research Foundation (DFG), the German Aerospace Center (DLR), the German Federal Ministry for Education and Research (BMBF), and the US National Science Foundation (NSF)."
 
 This approach ensures the recognition and respect for the significant efforts behind the data collection while promoting its open and respectful use.

--- a/orcestra_book/data_policy.md
+++ b/orcestra_book/data_policy.md
@@ -1,11 +1,11 @@
 # Data Policy
 
-ORCESTRA encourages free use and access to data. We trust in the integrity of the scientific community to honor the contributions of those who collected these data.
+ORCESTRA encourages free use and access to its data and relies on the integrity of the scientific community to ensure that this open data policy does not diminish the contributions of those who collected these data.
 
-The ORCESTRA data are a product of the collective efforts and funding of various independent research groups. It often represents years of work in developing, certifying, and operating instruments, often tied to specific research or Ph.D. projects. We ask users to respect the priority of the data collectors by coordinating use with the instrument Principal Investigators (PIs) and by clearly acknowledging the source of the data in any publications or presentations.
+ORCESTRA data are a product of the collective efforts of various independent research groups, whose efforts have often benefited from financial support by external funding agencies. The data represents years of work in developing, certifying, and operating instruments, often tied to specific research or Ph.D. projects. We ask users to respect the priority of the data collectors by coordinating their use of ORCESTRA data with the Principal Investigators (PIs) responsible for the data collection, and by clearly acknowledging the source of the data used in all publications and presentations.
 
 For publications using ORCESTRA data, please include this acknowledgement:
 
-> "The data used in this publication was collected during the ORCESTRA field campaign and is available through [insert institute name]. ORCESTRA is supported by the European Space Agency (ESA), the Max Planck Society (MPG), the German Research Foundation (DFG), the German Aerospace Center (DLR), the German Federal Ministry for Education and Research (BMBF), and the US National Science Foundation (NSF)."
+> "ORCESTRA was made possible thanks to the support of the Max Planck Society (MPG), the European Research Counceil through Grant No. (XXX), the German Research Foundation (DFG), the German Aerospace Center (DLR), the German Federal Ministry for Education and Research (BMBF), the French National Centre for Scientific Research (CNRS), the European Space Agency (ESA), and the US National Science Foundation (NSF), through Grant No. YYY".  [The specific data used in this study was made available by instution/person XY thanks with partial support from agency XYZ]
 
-This approach ensures the recognition and respect for the significant efforts behind the data collection while promoting its open and respectful use.
+To ensure the recognition of contributions to the data collection, while promoting its open and respectful use.

--- a/orcestra_book/data_policy.md
+++ b/orcestra_book/data_policy.md
@@ -1,0 +1,7 @@
+# Data Policy
+
+ORCESTRA follows the open data policy established for NARVAL which  means that we do not intend to police the use of, or access to, the data. Instead we rely on the good will and scientific integrity of those interested in using the data to respect the efforts of those whose were responsible for its collection by adhering to the two guidelines below:
+
+Unlike in some other contexts the ORCESTRA data is made available through the individual efforts and particular funding of a number of independent research groups. Often the data that is collected represents the fruits of many years of effort to develop, certify and operate an instrument. This effort is often connected to individual research projects, and even PhD projects. For this reason, we consider it a matter of scientific integrity for users to respect the priority of those who collected the data, by coordinating your planned use with the instrument PIs (list will follow), and making an effort to explicitly and clearly acknowledge the origin of the data when it is presented to a broader community in the form of publications or presentations.
+
+For publications that include ORCESTRA data, include the following in your acknowledgements: The data used in this publication was gathered in the ORCESTRA field campaign and is made available through [insert name of the institute]. ORCESTRA is funded with support of the European Space Agency (ESA), the Max Planck Society (MPG), the German Research Foundation (DFG) and the German Aerospace Center (DLR).

--- a/orcestra_book/data_policy.md
+++ b/orcestra_book/data_policy.md
@@ -1,6 +1,6 @@
 # Data Policy
 
-ORCESTRA encourages free use and access to data without strict control. We trust in the integrity of the scientific community to honor the contributions of those who collected these data.
+ORCESTRA encourages free use and access to data. We trust in the integrity of the scientific community to honor the contributions of those who collected these data.
 
 The ORCESTRA data are a product of the collective efforts and funding of various independent research groups. It often represents years of work in developing, certifying, and operating instruments, often tied to specific research or Ph.D. projects. We ask users to respect the priority of the data collectors by coordinating use with the instrument Principal Investigators (PIs) and by clearly acknowledging the source of the data in any publications or presentations.
 


### PR DESCRIPTION
This PR builds heavily on the work in #26, but aims for a more streamlined version of the data policy. While the content of the policy remains the same, the general structure is less rule-based and attempts to merely motivate the ideas.