### PR TITLE
Fix spacing of badge elements

### DIFF
--- a/orcestra_book/_ext/flight_reports.py
+++ b/orcestra_book/_ext/flight_reports.py
@@ -61,9 +61,14 @@ class BadgesRole(SphinxRole):
         fm = load_frontmatter(self.env.doc2path(self.env.docname))
         categories = fm.get("categories", [])
 
-        nodes = [create_badge(cat_id) for cat_id in categories]
+        node_list = [create_badge(cat_id) for cat_id in categories]
 
-        return nodes, []
+        node = nodes.raw(
+            text=" ".join(n.astext() for n in node_list),
+            format="html",
+        )
+
+        return [node], []
 
 
 class FrontmatterRole(SphinxRole):

--- a/orcestra_book/_static/custom.css
+++ b/orcestra_book/_static/custom.css
@@ -57,11 +57,6 @@ html {
   border-radius: 0.25em;
 }
 
-/* HACK: Fix spacing between span elements in "row view". */
-a:has(> span.badge) + a:has(> span.badge) {
-    margin-left: 0.25em;
-}
-
 .cat-a {
   background-color: #33691E;
   color: #fff;


### PR DESCRIPTION
In the old implementation, the row of badges did **not** include any whitespace between the different badges. As a result, the website rendered the badges without any spacing. As a hack, and additional spacing was added (which also affected the table view).

This PR adds a fix that explicitly adds whitespace between the individual badges and thus restores the proper rendering without the CSS hack