### PR TITLE
Suggestion: Restructuring TOC

### DIFF
--- a/orcestra_book/_toc.yml
+++ b/orcestra_book/_toc.yml
@@ -17,11 +17,14 @@ chapters:
 - file: science
   #sections:
     #- file: gate
-- file: strategy
+#- file: strategy
 - file: preparation
   sections:
-    - file: virtual_campaign
     - file: water_vapour_overview
+    - file: hera5
+    - file: hifs
+    - file: temperature_example
+    - file: virtual_campaign
 - file: operation
 - file: data
   sections:
@@ -29,9 +32,10 @@ chapters:
     #- file: data_creation
     #- file: data_access
     - file: data_concept
-    - file: hera5
-    - file: hifs
-    - file: temperature_example
+    #- file: water_vapour_overview
+    #- file: hera5
+    #- file: hifs
+    #- file: temperature_example
 #- file: results
 #  sections:
 #    - file: showcases

--- a/orcestra_book/strategy.md
+++ b/orcestra_book/strategy.md
@@ -1,1 +1,0 @@
-# Strategy

--- a/orcestra_book/water_vapour_overview.md
+++ b/orcestra_book/water_vapour_overview.md
@@ -10,7 +10,7 @@ kernelspec:
   name: python3
 ---
 
-# water vapour in campaign area
+# Water Vapour in Campaign Area
 
 We can use the `HERA5` dataset (ERA5 on HEALPix) to get a quick overview over the water vapour structure in the field campaign area.
 


### PR DESCRIPTION
Removing the section `strategy` as it is empty so far and probably irritating without content. I put all the code examples into `preparation`. 

And in `water_vapor_overview.md` typo in the title was fixed.