### PR TITLE
plans: no explicit map extent

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -24,5 +24,5 @@ dependencies:
   - pip
   - pip:
     - easygems>=0.0.3
-    - orcestra
+    - orcestra>0.0.8
     - pybtex-apa-style

--- a/orcestra_book/plans/HALO-20240811a.md
+++ b/orcestra_book/plans/HALO-20240811a.md
@@ -98,7 +98,6 @@ ds = cat.HIFS(refdate=date_time_str, reftime=date_time.hour).to_dask()
 cwv_flight_time = ds["tcwv"].sel(time=flight_time, method = "nearest")
 
 ax = path_preview(path)
-ax.set_extent([-35, -10, 0, 20])
 plot_cwv(cwv_flight_time)
 
 

--- a/orcestra_book/plans/HALO-20240813a.md
+++ b/orcestra_book/plans/HALO-20240813a.md
@@ -107,7 +107,6 @@ ds = cat.HIFS(refdate=date_time_str, reftime=date_time.hour).to_dask()
 cwv_flight_time = ds["tcwv"].sel(time=flight_time, method = "nearest")
 
 ax = path_preview(path)
-ax.set_extent([-35, -10, 0, 25])
 plot_cwv(cwv_flight_time)
 
 


### PR DESCRIPTION
The new release of the orcestra package, will automatically set a good aspect ratio for flightplan quick plots, thus setting an explicit extent is not necessary anymore. Not setting the extent leads to nicer figures.

NOTE: This will require a release of pyorcestra with https://github.com/orcestra-campaign/pyorcestra/pull/14 merged.