### PR TITLE
Check Sal Airport runway restrictions

### DIFF
--- a/orcestra_book/operation.md
+++ b/orcestra_book/operation.md
@@ -27,3 +27,14 @@
 ```
 
 ````
+
+```{warning}
+At Sal Island the runway will be closed according to the following schedule (UTC):
+
+* Monday: 02:20–12:35
+* Tuesday: 02:20–09:45
+* Wednesday: 02:20–12:30
+* Thursday: 02:20–11:10
+* Friday: 02:20–10:00
+* Saturday: 02:50–08:00
+```


### PR DESCRIPTION
This PR:
* Adds an overview of Sal Airport runway restrictions to the operations page
* Automatically checks if the planned take-off in each flight plan complies with the restrictions 

This closes https://github.com/orcestra-campaign/book/issues/87