### PR TITLE
Make the airport restriction check more robust

### DIFF
--- a/orcestra_book/_ext/reports.py
+++ b/orcestra_book/_ext/reports.py
@@ -148,6 +148,7 @@ def check_flight_plan(app=None):
             k: datetime.datetime.fromisoformat(v["plan"]["takeoff"])
             for k, v in sorted(metadata.items())
             if regex.match(k)
+            if "plan" in v  # Only check flights with plan
         }
 
         for flight_id, takeoff in planned_takeoffs.items():


### PR DESCRIPTION
Check only flights that have a plan. The old implementation crashed in cases where there was a report but no plan. While this should not happen in practice, this check prevents a crash.