### PR TITLE
Add UTC offsets to takeoff/landing

### DIFF
--- a/orcestra_book/_templates/operation_atr.md
+++ b/orcestra_book/_templates/operation_atr.md
@@ -13,8 +13,8 @@ Flight-ID | Date | Takeoff | Landing | PI | Categories
 {% for k, v in flights.items() -%}
 {% set c1 = v["refs"]|join(", ") -%}
 {% set c2 = v["takeoff"].strftime("%d %B %Y") -%}
-{% set c3 = v["takeoff"].strftime("%X") -%}
-{% set c4 = v["landing"].strftime("%X") -%}
+{% set c3 = v["takeoff_local"]|lt_utc -%}
+{% set c4 = v["landing_local"]|lt_utc -%}
 {% set c5 = v["pi"] -%}
 {{ k }} ({{ c1 }}) | {{ c2 }} | {{ c3 }} | {{ c4 }} | {{ c5 }} | {% for cat in v["categories"] %}{flight-cat}`{{cat}}` {% endfor %}
 {% endfor -%}

--- a/orcestra_book/_templates/operation_halo.md
+++ b/orcestra_book/_templates/operation_halo.md
@@ -13,8 +13,8 @@ Flight-ID | Date | Takeoff | Landing | PI | Nickname | Categories
 {% for k, v in flights.items() -%}
 {% set c1 = v["refs"]|join(", ") -%}
 {% set c2 = v["takeoff"].strftime("%d %B %Y") -%}
-{% set c3 = v["takeoff"].strftime("%X") -%}
-{% set c4 = v["landing"].strftime("%X") -%}
+{% set c3 = v["takeoff_local"]|lt_utc -%}
+{% set c4 = v["landing_local"]|lt_utc -%}
 {% set c5 = v["pi"] -%}
 {% set c6 = v["nickname"] -%}
 {{ k }} ({{ c1 }}) | {{ c2 }} | {{ c3 }} | {{ c4 }} | {{ c5 }} | {{ c6 }} | {% for cat in v["categories"] %}{flight-cat}`{{cat}}` {% endfor %}

--- a/orcestra_book/_templates/operation_kingair.md
+++ b/orcestra_book/_templates/operation_kingair.md
@@ -8,8 +8,8 @@ Flight-ID | Date | Takeoff | Landing | PI | Nickname | Categories
 {% for k, v in flights.items() -%}
 {% set c1 = v["refs"]|join(", ") -%}
 {% set c2 = v["takeoff"].strftime("%d %B %Y") -%}
-{% set c3 = v["takeoff"].strftime("%X") -%}
-{% set c4 = v["landing"].strftime("%X") -%}
+{% set c3 = v["takeoff_local"]|lt_utc -%}
+{% set c4 = v["landing_local"]|lt_utc -%}
 {% set c5 = v["pi"] -%}
 {% set c6 = v["nickname"] -%}
 {{ k }} ({{ c1 }}) | {{ c2 }} | {{ c3 }} | {{ c4 }} | {{ c5 }} | {{ c6 }} | {% for cat in v["categories"] %}{flight-cat}`{{cat}}` {% endfor %}

--- a/orcestra_book/operation/airport_info.yaml
+++ b/orcestra_book/operation/airport_info.yaml
@@ -1,0 +1,20 @@
+EDJA:
+  lat: 47.9888
+  lon: 10.2395
+  name: "Allg\xE4u Airport"
+  tzinfo: Europe/Berlin
+GVAC:
+  lat: 16.7414
+  lon: -22.9494
+  name: Amilcar Cabral International Airport
+  tzinfo: Atlantic/Cape_Verde
+GVNP:
+  lat: 14.9245
+  lon: -23.4935
+  name: Praia International Airport
+  tzinfo: Atlantic/Cape_Verde
+TBPB:
+  lat: 13.0746
+  lon: -59.4925
+  name: Grantley Adams International Airport
+  tzinfo: America/Barbados

--- a/orcestra_book/plans/KA-20240815a.md
+++ b/orcestra_book/plans/KA-20240815a.md
@@ -13,8 +13,8 @@ platform: King Air
 flight_id: KA-20240815a
 takeoff: "2024-08-15 13:50:00Z"
 landing: "2024-08-15 16:20:00Z"
-departure_airport: RAI
-arrival_airport: RAI
+departure_airport: GVNP
+arrival_airport: GVNP
 crew:
   - name: Robert Oscar David
     job: PI

--- a/orcestra_book/plans/KA-20240820a.md
+++ b/orcestra_book/plans/KA-20240820a.md
@@ -13,8 +13,8 @@ platform: King Air
 flight_id: KA-20240820a
 takeoff: "2024-08-20 13:50:00Z"
 landing: "2024-08-20 17:20:00Z"
-departure_airport: RAI
-arrival_airport: RAI
+departure_airport: GVNP
+arrival_airport: GVNP
 crew:
   - name: Robert Oscar David
     job: PI

--- a/orcestra_book/plans/KA-20240822a.md
+++ b/orcestra_book/plans/KA-20240822a.md
@@ -13,8 +13,8 @@ platform: King Air
 flight_id: KA-20240822a
 takeoff: "2024-08-22 14:40:00Z"
 landing: "2024-08-22 16:40:00Z"
-departure_airport: RAI
-arrival_airport: RAI
+departure_airport: GVNP
+arrival_airport: GVNP
 crew:
   - name: Tim Carlsen
     job: PI

--- a/orcestra_book/reports/HALO-20240811a.md
+++ b/orcestra_book/reports/HALO-20240811a.md
@@ -5,7 +5,7 @@ nickname: Firsts (or alien on board)
 takeoff: "2024-08-11 11:59:30Z"
 landing: "2020-08-11 20:35:00Z"
 departure_airport: GVAC
-arrical_airport: GVAC
+arrival_airport: GVAC
 crew:
   - name: Bjorn Stevens
     job: PI

--- a/orcestra_book/reports/HALO-20240813a.md
+++ b/orcestra_book/reports/HALO-20240813a.md
@@ -5,7 +5,7 @@ nickname: Tri-location
 takeoff: "2024-08-13 11:59:30Z"
 landing: "2020-08-13 20:35:00Z"
 departure_airport: GVAC
-arrical_airport: GVAC
+arrival_airport: GVAC
 crew:
   - name: Forian Ewald
     job: PI

--- a/orcestra_book/reports/HALO-20240816a.md
+++ b/orcestra_book/reports/HALO-20240816a.md
@@ -5,7 +5,7 @@ nickname: EarthCARE echo
 takeoff: "2024-08-16 11:30:00Z"
 landing: "2020-08-16 20:10:00Z"
 departure_airport: GVAC
-arrical_airport: GVAC
+arrival_airport: GVAC
 crew:
   - name: Bjorn Stevens
     job: PI


### PR DESCRIPTION
This PR adds explicit UTC offsets to all takeoff and landing times. This way, it is possible to print both local time (LT) and UTC if wanted. Here is an updated example of the HALO overview table:

<img width="818" alt="HALO overview with local time and UTC" src="https://github.com/user-attachments/assets/d2ae75df-48b8-4b3e-bbc9-b12ebfd1692e">

This closes #76 