### PR TITLE
Constrain scheduled Github action to upstream repo

### DIFF
--- a/.github/workflows/buildbook.yaml
+++ b/.github/workflows/buildbook.yaml
@@ -19,6 +19,8 @@ env:
 
 jobs:
   build:
+    # Only run scheduled jobs on the upstream repo
+    if: github.repository == 'orcestra-campaing/book' || github.event_name != 'schedule'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/buildbook.yaml
+++ b/.github/workflows/buildbook.yaml
@@ -27,9 +27,9 @@ jobs:
         shell: bash -l {0}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: initialize conda
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         activate-environment: orcestra_book
         auto-activate-base: false
@@ -37,7 +37,7 @@ jobs:
         miniforge-variant: Mambaforge
         miniforge-version: latest
     - name: restore conda environment from cache
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         path: ${{ env.CONDA }}/envs
         key:
@@ -49,14 +49,14 @@ jobs:
       if: steps.conda_cache.outputs.cache-hit != 'true'
       id: install_conda_env
     - name: upload conda environment to cache
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4
       if: steps.install_conda_env.outcome == 'success'
       with:
         path: ${{ env.CONDA }}/envs
         key:
           conda-${{ runner.os }}--${{ runner.arch }}--${{ hashFiles('environment.yml') }}-${{ env.CONDA_CACHE_NUMBER }}
     - name: setting up notebook execution cache
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         path: |
           orcestra_book/_build/.jupyter_cache
@@ -69,7 +69,7 @@ jobs:
         conda info
         jupyter-book build -W -n --keep-going orcestra_book
     - name: save execution cache
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4
       if: always()
       with:
         path: |
@@ -77,7 +77,7 @@ jobs:
         key: notebooks-${{ runner.os }}-${{ hashFiles('environment.yml') }}-${{ github.run_id }}-${{ github.run_attempt }}
     - name: Archive build artifacts
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: html
         path: |
@@ -97,17 +97,17 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Download compiled book
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: html
           path: html
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
           path: 'html'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This PR limits the scheduled execution of the build process to the organisation repo. It's a somewhat weird hack, but I haven't found a cleaner way to adjust the `cron` entry.

This closes #138 