### PR TITLE
Improve EarthCARE forecast

### DIFF
--- a/.github/workflows/buildbook.yaml
+++ b/.github/workflows/buildbook.yaml
@@ -64,6 +64,10 @@ jobs:
         restore-keys: |
           notebooks-${{ runner.os }}-${{ hashFiles('environment.yml') }}-${{ github.run_id }}-
           notebooks-${{ runner.os }}-${{ hashFiles('environment.yml') }}-
+    - name: Invalidate EarthCARE cache
+      if: github.event_name == 'schedule'
+      # Invalidate the cache for the EarthCARE track to always show the latest prediction
+      run: jcache notebook -p orcestra_book/_build/.jupyter_cache/ invalidate orcestra_book/earthcare.md
     - name: build book
       run: |
         conda info

--- a/orcestra_book/earthcare.md
+++ b/orcestra_book/earthcare.md
@@ -49,14 +49,15 @@ import warnings
 # Define timeframes for long term prediction (LTP) and preliminary (PRE)
 start_date = datetime.now().date()
 dates_ltp = [start_date + timedelta(days=7) + timedelta(days=i) for i in range(14)]
-dates_pre = [start_date + timedelta(days=i) for i in range(7)]
 
 # Define which satellite predictions schould be used 
 issue_date_ltp = '2024-08-05'
+# Always plot seven-day forecast of the most recently published prediction (PRE)
 issue_date_pre = pd.read_csv(
     "https://sattracks.orcestra-campaign.org/index.csv",
     parse_dates=["forecast_day"],
 ).forecast_day.loc[0].strftime("%Y-%m-%d")
+dates_pre = [datetime.fromisoformat(issue_date_pre) + timedelta(days=i) for i in range(7)]
 
 # Ignore warning from using an old forecast. LTP forecast will always be older than latest PRE forecast
 warnings.filterwarnings("ignore") 


### PR DESCRIPTION
This PR
* makes sure that the seven-day forecast is always counted from the issued date and not "today"
* (try to) invalidate the EarthCARE cache during the nightly builds