### PR TITLE
Increase maximum runtime for temperature comparison

### DIFF
--- a/orcestra_book/temperature_example.md
+++ b/orcestra_book/temperature_example.md
@@ -8,6 +8,8 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+execution:
+  timeout: 60
 ---
 
 # Temperature comparison


### PR DESCRIPTION
It may be due to the hotel wifi, but the "temperature comparison" notebook often times out. We can also leave it as it is already in the build cache and will likely rarely render