### PR TITLE
Publish scheduled (midnight) builds

### DIFF
--- a/.github/workflows/buildbook.yaml
+++ b/.github/workflows/buildbook.yaml
@@ -89,7 +89,7 @@ jobs:
 
   publish:
     needs: build
-    if: "always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'orcestra-campaign'"
+    if: "always() && github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'orcestra-campaign')"
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
At the moment, the website is build automatically every day at midnight, but **not published**. This PR fixes the if-condition that causes the publication to be skipped.


This closes #164 