### PR TITLE
Hide science section from TOC

### DIFF
--- a/orcestra_book/_toc.yml
+++ b/orcestra_book/_toc.yml
@@ -44,4 +44,4 @@ chapters:
       title: FAQ
 - file: blog
 - file: coordination
-- file: references
+

--- a/orcestra_book/_toc.yml
+++ b/orcestra_book/_toc.yml
@@ -23,7 +23,6 @@ chapters:
   - file: bco
   - file: cvao
   - file: rvmeteor
-- file: science
 - file: operation
   sections:
     - file: operation/atr

--- a/orcestra_book/references.md
+++ b/orcestra_book/references.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 # References
 ```{bibliography}
 ```

--- a/orcestra_book/science.md
+++ b/orcestra_book/science.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 # Science
 
 ## The ITCZ


### PR DESCRIPTION
Hide the "Science" section from the table of contents but keep it as orphaned page to keep shared links working.

This closes #184 