### PR TITLE
Remove daily LAM simulations from TOC

### DIFF
--- a/orcestra_book/_ext/lam_videos.py
+++ b/orcestra_book/_ext/lam_videos.py
@@ -1,3 +1,4 @@
+import pathlib
 from datetime import datetime, timedelta
 
 from docutils import nodes
@@ -91,8 +92,25 @@ class LimitedAreaVideos(SphinxDirective):
         return node_list
 
 
+class VideoOverview(SphinxDirective):
+    def run(self):
+        src = pathlib.Path(self.env.srcdir)
+
+        p = nodes.paragraph()
+        p["classes"].append("multi-column")
+        for doc in sorted((src / "lam").glob("*.md"), reverse=True):
+            href = doc.relative_to(src, walk_up=True).with_suffix(".html").as_posix()
+            datestr = datetime.fromisoformat(doc.stem).strftime("%Y-%m-%d")
+
+            p += get_link_node(source_url=href, message=datestr)
+            p += nodes.Text(" ", " ")
+
+        return [p]
+
+
 def setup(app):
     app.add_directive("lam-videos", LimitedAreaVideos)
+    app.add_directive("list-videos", VideoOverview)
 
     return {
         "version": "0.1",

--- a/orcestra_book/_static/custom.css
+++ b/orcestra_book/_static/custom.css
@@ -84,3 +84,7 @@ html {
   max-width: 150px;
   height: auto;
 }
+
+.multi-column {
+  column-width: 100px;
+}

--- a/orcestra_book/_toc.yml
+++ b/orcestra_book/_toc.yml
@@ -37,8 +37,6 @@ chapters:
     - file: hera5
     - file: hifs
     - file: lam
-      sections:
-        - glob: lam/*
     - file: water_vapour_overview
     - file: temperature_example
     - file: faq

--- a/orcestra_book/lam.md
+++ b/orcestra_book/lam.md
@@ -10,5 +10,5 @@ The whole dataset is stored on [Levante (DKRZ)](https://docs.dkrz.de/doc/levante
 
 ## Daily simulations
 
-```{tableofcontents}
+```{list-videos}
 ```

--- a/orcestra_book/lam/20240809.md
+++ b/orcestra_book/lam/20240809.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 # 2024-08-09
 
 ```{lam-videos}

--- a/orcestra_book/lam/20240810.md
+++ b/orcestra_book/lam/20240810.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 # 2024-08-10
 
 ```{lam-videos}

--- a/orcestra_book/lam/20240811.md
+++ b/orcestra_book/lam/20240811.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 # 2024-08-11
 
 ```{lam-videos}

--- a/orcestra_book/lam/20240812.md
+++ b/orcestra_book/lam/20240812.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 # 2024-08-12
 
 ```{lam-videos}

--- a/orcestra_book/lam/20240813.md
+++ b/orcestra_book/lam/20240813.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 # 2024-08-13
 
 ```{lam-videos}

--- a/orcestra_book/lam/20240814.md
+++ b/orcestra_book/lam/20240814.md
@@ -1,3 +1,7 @@
+---
+orphan: true
+---
+
 # 2024-08-14
 
 ```{lam-videos}


### PR DESCRIPTION
This PR:
* removes the daily LAM simulations from the table of contents
* adds a new directive that creates a multi-column paragraph that contains an ordered list of all simulations