### PR TITLE
Add infrastructure to use MyST files in jupyterlab

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,8 +13,11 @@ dependencies:
   - healpy>=1.16.3
   - intake-xarray
   - intake[dataframe]<2.0.0 # since intake 0.6.1 to_dask() doesn't work anymore without the [dataframe] specification due to a missing msgpack dependency
+  - ipykernel
   - jinja2
   - jupyter-book
+  - jupyterlab
+  - jupytext
   - matplotlib
   - netcdf4
   - numpy

--- a/jupytext.toml
+++ b/jupytext.toml
@@ -1,0 +1,1 @@
+notebook_metadata_filter="all,-language_info,-jupytext.text_representation.format_version,-jupytext.text_representation.jupytext_version,-kernelspec.display_name"


### PR DESCRIPTION
This PR:
* adds a `juptext.toml` to configure jupytext in a way to preserve additional metadata
* removes metadata that is likely to be overwritten on every machine (e.g. kernel name)
* adds `jupyterlab`, `jupytext`, and `ipykernel` to the python environment to ease interactive work