### PR TITLE
add links to atr flight reports

### DIFF
--- a/orcestra_book/reports/ATR-20240810a.md
+++ b/orcestra_book/reports/ATR-20240810a.md
@@ -49,4 +49,8 @@ categories: []
 ```{badges}
 ```
 
-[Flight Report](./REPORT-ATR-20240810a.pdf)
+## Report
+
+* **[Flight Report](https://thredds-x.ipsl.fr/thredds/fileServer/MAESTRO/INSITU/AIRCRAFT/ATR/REPORTS/ATR-20240810a_RF01_as23_Flight_Report_MAESTRO.pdf)** from MAESTRO Operational Data Center
+
+* [Cached Flight Report](./REPORT-ATR-20240810a.pdf) as of 26 August 2024.

--- a/orcestra_book/reports/ATR-20240811a.md
+++ b/orcestra_book/reports/ATR-20240811a.md
@@ -49,4 +49,8 @@ categories: [ec_under, c_atr]
 ```{badges}
 ```
 
-[Flight Report](./REPORT-ATR-20240811a.pdf)
+## Report
+
+* **[Flight Report](https://thredds-x.ipsl.fr/thredds/fileServer/MAESTRO/INSITU/AIRCRAFT/ATR/REPORTS/ATR-20240811a_RF02_as24_Flight_Report_MAESTRO.pdf)** from MAESTRO Operational Data Center
+
+* [Cached Flight Report](./REPORT-ATR-20240811a.pdf) as of 26 August 2024.

--- a/orcestra_book/reports/ATR-20240813b.md
+++ b/orcestra_book/reports/ATR-20240813b.md
@@ -48,4 +48,8 @@ orphan: true
 ```{badges}
 ```
 
-[Flight Report](./REPORT-ATR-20240813b.pdf)
+## Report
+
+* **[Flight Report](https://thredds-x.ipsl.fr/thredds/fileServer/MAESTRO/INSITU/AIRCRAFT/ATR/REPORTS/ATR-20240813b_RF04_as26_Flight_Report_MAESTRO.pdf)** from MAESTRO Operational Data Center
+
+* [Cached Flight Report](./REPORT-ATR-20240813b.pdf) as of 26 August 2024.

--- a/orcestra_book/reports/ATR-20240816a.md
+++ b/orcestra_book/reports/ATR-20240816a.md
@@ -50,4 +50,8 @@ categories: []
 ```{badges}
 ```
 
-[Flight Report](./REPORT-ATR-20240816a.pdf)
+## Report
+
+* **[Flight Report](https://thredds-x.ipsl.fr/thredds/fileServer/MAESTRO/INSITU/AIRCRAFT/ATR/REPORTS/ATR-20240816a_RF06_as28_Flight_Report_MAESTRO.pdf)** from MAESTRO Operational Data Center
+
+* [Cached Flight Report](./REPORT-ATR-20240816a.pdf) as of 26 August 2024.

--- a/orcestra_book/reports/ATR-20240816b.md
+++ b/orcestra_book/reports/ATR-20240816b.md
@@ -49,4 +49,8 @@ categories: [c_atr]
 ```{badges}
 ```
 
-[Flight Report](./REPORT-ATR-20240816b.pdf)
+## Report
+
+* **[Flight Report](https://thredds-x.ipsl.fr/thredds/fileServer/MAESTRO/INSITU/AIRCRAFT/ATR/REPORTS/ATR-20240816b_RF07_as29_Flight_Report_MAESTRO.pdf)** from MAESTRO Operational Data Center
+
+* [Cached Flight Report](./REPORT-ATR-20240816b.pdf) as of 26 August 2024.

--- a/orcestra_book/reports/ATR-20240820a.md
+++ b/orcestra_book/reports/ATR-20240820a.md
@@ -50,4 +50,8 @@ categories: [ec_under]
 ```{badges}
 ```
 
-[Flight Report](./REPORT-ATR-20240820a.pdf)
+## Report
+
+* **[Flight Report](https://thredds-x.ipsl.fr/thredds/fileServer/MAESTRO/INSITU/AIRCRAFT/ATR/REPORTS/ATR-20240820_RF09_as31_Flight_Report_MAESTRO.pdf)** from MAESTRO Operational Data Center
+
+* [Cached Flight Report](./REPORT-ATR-20240820a.pdf) as of 26 August 2024.


### PR DESCRIPTION
Added links of flight reports located at the MAESTRO operational data center. In theory these should be updated as flight reports are edited. However, until that is confirmed, I will keep the locally stored pdf flight report.