### PR TITLE
Fix flight id for HALO transfer flight (EDJA->GVAC)

### DIFF
--- a/orcestra_book/plans/HALO-20240809b.md
+++ b/orcestra_book/plans/HALO-20240809b.md
@@ -10,7 +10,7 @@ kernelspec:
   language: python
   name: python3
 platform: HALO
-flight_id: HALO-20240809a
+flight_id: HALO-20240809b
 takeoff: "2024-08-09 09:30:00Z"
 landing: "2024-08-09 16:30:00Z"
 departure_airport: EDJA


### PR DESCRIPTION
Technically, the flight id HALO-2040809**a** was for the trip from OP to Memmingen. The actual transfer to Sal had the id HALO-20240809**b** (according to the flight plan shared by FX and BAHAMAS).