### PR TITLE
HALO-20240903a: use FlightPlan object

### DIFF
--- a/orcestra_book/plans/HALO-20240903a.md
+++ b/orcestra_book/plans/HALO-20240903a.md
@@ -56,7 +56,7 @@ The flight is planned to take off at {front}`takeoff`.
 from datetime import datetime
 import orcestra.sat
 from orcestra.flightplan import LatLon, IntoCircle, FlightPlan, bco, sal, mindelo, \
-                                find_ec_lon, ec_time_at_lat \
+                                point_on_track \
 
 # Some fixed coordinates
 
@@ -83,21 +83,18 @@ ec_track = orcestra.sat.SattrackLoader("EARTHCARE", ec_fcst_time, kind="PRE") \
     .get_track_for_day(f"{flight_time:%Y-%m-%d}")\
     .sel(time=slice(f"{flight_time:%Y-%m-%d} 14:00", None))
 
-ec_lons, ec_lats = ec_track.lon.values, ec_track.lat.values
-
 # Create elements of track
 
-ec_north = LatLon(14.0, find_ec_lon(14.0, ec_lons, ec_lats), label = "ec_north")
-ec_south = LatLon( 2.0, find_ec_lon( 2.0, ec_lons, ec_lats), label = "ec_south")
+ec_north = point_on_track(ec_track, lat=14).assign(label="ec_north")
+ec_south = point_on_track(ec_track, lat=2).assign(label="ec_south")
 
-c_north = LatLon(11.50, find_ec_lon(11.50, ec_lons, ec_lats), label = "c_north")
-c_south = LatLon( 4.00, find_ec_lon( 4.00, ec_lons, ec_lats), label = "c_south")
-c_mid   = LatLon( 7.75, find_ec_lon( 7.75, ec_lons, ec_lats), label = "c_mid")
+c_north = point_on_track(ec_track, lat=11.5).assign(label="c_north")
+c_south = point_on_track(ec_track, lat=4).assign(label="c_south")
+c_mid   = point_on_track(ec_track, lat=7.75).assign(label="c_mid")
 c_atr   = c_atr_se
 
 lat_ec_under = c_north.towards(c_south, distance = radius).lat
-ec_under = LatLon(lat_ec_under, find_ec_lon(lat_ec_under, ec_lons, ec_lats), label = "ec_under")
-ec_under = ec_under.assign(time=ec_time_at_lat(ec_track, float(ec_under.lat)), note="meet EarthCARE")
+ec_under = point_on_track(ec_track, lat=lat_ec_under, with_time=True).assign(label="ec_under", note="meet EarthCARE")
 
 # Additional Waypoints
 
@@ -169,7 +166,7 @@ if (forecast_overlay):
     plot_cwv(cwv_flight_time, levels = [50.0, 60.0], ax=ax)
     plt.title(f"{flight_time}\n(CWV forecast issued on {ifs_fcst_time})")
 
-plt.plot(ec_lons, ec_lats, c='k', ls='dotted')
+plt.plot(ec_track.lon, ec_track.lat, c='k', ls='dotted')
 plot_path(plan, ax, color="C1")
 
 if (True):

--- a/orcestra_book/plans/HALO-20240903a.md
+++ b/orcestra_book/plans/HALO-20240903a.md
@@ -194,7 +194,3 @@ vertical_preview(waypoints)
 
 plan.export()
 ```
-
-```{code-cell} ipython3
-
-```

--- a/orcestra_book/plans/HALO-20240903a.md
+++ b/orcestra_book/plans/HALO-20240903a.md
@@ -56,8 +56,8 @@ The flight is planned to take off at {front}`takeoff`.
 from dataclasses import asdict
 from datetime import datetime
 import orcestra.sat
-from orcestra.flightplan import LatLon, IntoCircle, expand_path, bco, sal, mindelo, \
-                                find_ec_lon, ec_time_at_lat, to_kml \
+from orcestra.flightplan import LatLon, IntoCircle, FlightPlan, bco, sal, mindelo, \
+                                find_ec_lon, ec_time_at_lat \
 
 # Some fixed coordinates
 
@@ -98,15 +98,15 @@ c_atr   = c_atr_se
 
 lat_ec_under = c_north.towards(c_south, distance = radius).lat
 ec_under = LatLon(lat_ec_under, find_ec_lon(lat_ec_under, ec_lons, ec_lats), label = "ec_under")
-ec_under = ec_under.assign(time=ec_time_at_lat(ec_track, float(ec_under.lat)))
+ec_under = ec_under.assign(time=ec_time_at_lat(ec_track, float(ec_under.lat)), note="meet EarthCARE")
 
 # Additional Waypoints
 
 extra_waypoints = [
-    c_north.towards(ec_north, distance = radius).assign(label="xwp1"),
-    c_mid.towards(c_north, distance = radius).assign(label="xwp3"),
-    c_mid.towards(c_south, distance = radius).assign(label="xwp4"),
-    c_south.towards(ec_south, distance = radius).assign(label="xwp5"),
+    c_north.towards(ec_north, distance = radius).assign(label="xwp1", note="Alternative center for c_north"),
+    c_mid.towards(c_north, distance = radius).assign(label="xwp3", note="Alternative center for c_mid"),
+    c_mid.towards(c_south, distance = radius).assign(label="xwp4", note="Alternative center for c_mid"),
+    c_south.towards(ec_south, distance = radius).assign(label="xwp5", note="Alternative center for c_south"),
 ]
 
 # Define Flight Paths
@@ -129,26 +129,6 @@ waypoints = [
      airport.assign(fl=0),
      ]
 
-path = expand_path(waypoints, dx=10e3)
-plan = path.isel(distance = path.waypoint_indices).to_dataframe().set_index("waypoint_labels")
-
-waypoint_centers = []
-for point in waypoints:
-    if isinstance(point, IntoCircle):
-        point = point.center
-    waypoint_centers.append(point)
-
-notes = {'c_south_in':f'{radius/1852:2.0f} nm circle centered at {c_south.format_pilot()}, enter from south, CCW',
-        'c_mid_in':f'{radius/1852:2.0f} nm circle centered at {c_mid.format_pilot()}, enter from south, CCW',
-        'c_north_in':f'{radius/1852:2.0f} nm circle centered at {c_north.format_pilot()}, enter from north, CCW',
-        'c_atr_in':f'{atr_radius/1852:2.0f} nm circle centered at {c_atr_se.format_pilot()}, enter from west, CCW',
-        'ec_under':f'EarthCARE at this point at {str(ec_time_at_lat(ec_track, float(ec_under.lat)))[11:19]} UTC',
-        'xwp2':'Alternative center for c_south',
-        'xwp3':'Alternative center for c_mid',
-        'xwp4':'Alternative center for c_south',
-        'xwp_atr':'Alternative center for c_atr',
-         }
-
 crew = {'Mission PI': 'Bjorn Stevens',
         'DropSondes': 'Nina Robbins',
         'HAMP': 'Clara Bayley',
@@ -159,8 +139,10 @@ crew = {'Mission PI': 'Bjorn Stevens',
         'Ground Support': 'Karsten Peters',
         }
 
-print(f"Flight index: {flight_index}")
-print (f"Take-off: {plan.iloc[0]['time']:%H:%M} UTC\nLanding:  {plan.iloc[-1]['time']:%H:%M} UTC\n")
+plan = FlightPlan(waypoints, flight_index, extra_waypoints=extra_waypoints, crew=crew)
+
+print(f"Flight index: {plan.flight_id}")
+print(f"Take-off: {plan.takeoff_time:%H:%M %Z}\nLanding:  {plan.landing_time:%H:%M %Z}\n")
 print(f"EarthCARE orbit estimate from: {ec_fcst_time}")
 ```
 
@@ -185,16 +167,11 @@ if (forecast_overlay):
     ifs_fcst_time = datetime(2024, 8, 28, 0, 0, 0)
     ds = intake.open_catalog("https://tcodata.mpimet.mpg.de/internal.yaml").HIFS(datetime = ifs_fcst_time).to_dask().pipe(egh.attach_coords)
     cwv_flight_time = ds["tcwv"].sel(time=flight_time, method = "nearest")
-    plot_cwv(cwv_flight_time, levels = [50.0, 60.0])
+    plot_cwv(cwv_flight_time, levels = [50.0, 60.0], ax=ax)
     plt.title(f"{flight_time}\n(CWV forecast issued on {ifs_fcst_time})")
 
 plt.plot(ec_lons, ec_lats, c='k', ls='dotted')
-plot_path(path, ax, color="C1")
-
-for wp in waypoint_centers:
-    plt.scatter(wp.lon,wp.lat,s=10.,color='k',zorder=0)
-for wp in extra_waypoints:
-    plt.scatter(wp.lon,wp.lat,s=10.,color='r',marker='o',zorder=0)
+plot_path(plan, ax, color="C1")
 
 if (True):
     airways = [natal,sal]
@@ -205,21 +182,7 @@ if (True):
 ```{code-cell} ipython3
 :tags: [hide-input]
 
-# Detailed overview with notes
-for index, row in plan.iterrows():
-    if (index[0]+index[-4:]!='c_out'):
-        print(f"{index:12s} {LatLon(row['lat'],row['lon']).format_pilot():20s}, FL{int(row['fl']):03d}, {row['time']:%H:%M:%S}, {notes.get(index,'')}" )
-print ('\n-- circle centers:')
-for point in waypoints:
-    if isinstance(point, IntoCircle):
-        point = point.center
-        print (f'{point.label:12s} {point.format_pilot()}')
-print ('\n-- extra waypoints:')
-for point in extra_waypoints:
-    print (f'{point.label:12s} {point.format_pilot()}, {notes.get(point.label,'')}' )
-print ('\nCrew:')
-for position,person in crew.items():
-    print (f'{position:22s} {person}')
+plan.show_details()
 ```
 
 ```{code-cell} ipython3
@@ -228,63 +191,12 @@ for position,person in crew.items():
 from orcestra.flightplan import vertical_preview
 
 vertical_preview(waypoints)
-plt.title("Profile")
 ```
 
 ```{code-cell} ipython3
 :tags: [hide-input]
 
-import os
-
-localdir = "/Users/m219063/Downloads/"
-if os.path.isdir(localdir):
-    with open(f"/Users/m219063/Downloads/{flight_index}.kml", "w") as f:
-        f.write(to_kml(path))
-        
-    with open( f"/Users/m219063/Downloads/{flight_index}_waypoints.txt", "w") as file:
-        file.write(f"Flight {flight_index}\n\n")
-        #
-        # DM Format
-        file.write("------------------------------------------------------------\n")
-        file.write("\nDM Format:\n")
-        file.write(" ".join(wp.format_1min() for wp in waypoint_centers) + "\n")
-        for point in extra_waypoints:
-            file.write(f"Extra waypoint: {point.format_1min()}\n")
-        #
-        # DM.mm format
-        file.write("\n------------------------------------------------------------\n")
-        file.write("\nDMmm Format:\n")
-        for point in waypoint_centers:
-            file.write(f"{point.format_pilot()}, {point.label}\n")
-        file.write("\n-- extra waypoints:\n")
-        for point in extra_waypoints:
-            file.write(f"{point.format_pilot()}, {notes.get(point.label,'')}\n")
-        #
-        # Detailed overview with notes
-        file.write("\n------------------------------------------------------------\n")
-        file.write(f"\n\nDetailed Overview:\n")
-        for index, row in plan.iterrows():
-            if (index[0]+index[-4:]!='c_out'):
-                file.write(f"{index:12s} {LatLon(row['lat'],row['lon']).format_pilot():20s}, FL{int(row['fl']):03d}, {row['time']:%H:%M:%S}, {notes.get(index,'')}\n" )
-        file.write ('\n -- circle centers:')
-        for point in waypoints:
-            if isinstance(point, IntoCircle):
-                point = point.center
-                file.write (f'\n{point.label:12s} {point.format_pilot()}')
-        file.write ('\n\n -- extra waypoints:')
-        for point in extra_waypoints:
-            file.write (f'\n{point.label:12s} {point.format_pilot()}, {notes.get(point.label,'')}' )
-        file.write ('\n\nCrew:')
-        for position,person in crew.items():
-            file.write (f'\n{position:22s} {person}')
-```
-
-```{code-cell} ipython3
-:tags: [hide-input]
-
-from orcestra.flightplan import export_flightplan
-
-export_flightplan(flight_index, path)
+plan.export()
 ```
 
 ```{code-cell} ipython3

--- a/orcestra_book/plans/HALO-20240903a.md
+++ b/orcestra_book/plans/HALO-20240903a.md
@@ -53,7 +53,6 @@ The flight is planned to take off at {front}`takeoff`.
 ```{code-cell} ipython3
 :tags: [hide-input]
 
-from dataclasses import asdict
 from datetime import datetime
 import orcestra.sat
 from orcestra.flightplan import LatLon, IntoCircle, FlightPlan, bco, sal, mindelo, \


### PR DESCRIPTION
This change makes use of https://github.com/orcestra-campaign/pyorcestra/pull/60 and https://github.com/orcestra-campaign/pyorcestra/pull/62, thus it **should not be merged** before  a new version of pyorcestra with the respective functionality is released.

The main change is the automatic export of the flight plan to TXT, based on the actual definition of the flight plan. In order to achieve this, all the information of the flight plan had to be collected in a new `FlightPlan` object, which should be used from now on instead of either the waypoint lists or the expanded dataset.