### PR TITLE
improve FlightPlan docs

### DIFF
--- a/orcestra_book/_templates/operation_halo.md
+++ b/orcestra_book/_templates/operation_halo.md
@@ -6,6 +6,7 @@
 
 * [for mission PI and flight planning](../plans/howto)
 * [for Documentation Scientist](../plans/doc-sci)
+* {doc}`../flightplan_docs`
 ```
 
 For an overview of all flight categories, [click here](flight_categories).

--- a/orcestra_book/plans/howto.md
+++ b/orcestra_book/plans/howto.md
@@ -21,10 +21,10 @@ The job of the PI on HALO is to:
 
 ### Creating a flight plan
 
-Once you know what you want to do in principle it needs to be made precise.  This is usually done using standardized elements, such a legs, circles, etc..  The essential element of a flight plan is a waypoint in the form a LatLon object as this is the basis of communication with ATC.  Waypoints can be discarded during a flight, but they are difficult to add on the fly.  Adding more waypoints ahead of time builds in flexibility, but adding too many can be a source of confusion.
+Once you know what you want to do in principle it needs to be made precise.  This is usually done using standardized elements, such a legs, circles, etc..  The essential element of a flight plan is a waypoint in the form a `LatLon` object as this is the basis of communication with ATC.  Waypoints can be discarded during a flight, but they are difficult to add on the fly.  Adding more waypoints ahead of time builds in flexibility, but adding too many can be a source of confusion.
 For an overview of the `FlightPlan` Python API, please have a look at {doc}`../flightplan_docs`.
 
-  - Be mindful of the standard elements (ec_under, ec_track, c_north, c_mid, c_south)
+  - Be mindful of the standard elements ({flight-cat}`ec_under`, {flight-cat}`ec_track`, {flight-cat}`c_north`, {flight-cat}`c_mid`, {flight-cat}`c_south`)
   - Be mindful of the general rule of flying the circles after the transect, this can be important to ensure we have enough time to get ATC permission for the circle and drops.
   - We use `ec_north` to refer to a waypoint that is along the EarthCARE track north of the perimeter of `c_north` 
   - Likewise `ec_south` refers to a waypoint that is along the EarthCARE track south of the perimeter of `c_south`

--- a/orcestra_book/plans/howto.md
+++ b/orcestra_book/plans/howto.md
@@ -22,6 +22,7 @@ The job of the PI on HALO is to:
 ### Creating a flight plan
 
 Once you know what you want to do in principle it needs to be made precise.  This is usually done using standardized elements, such a legs, circles, etc..  The essential element of a flight plan is a waypoint in the form a LatLon object as this is the basis of communication with ATC.  Waypoints can be discarded during a flight, but they are difficult to add on the fly.  Adding more waypoints ahead of time builds in flexibility, but adding too many can be a source of confusion.
+For an overview of the `FlightPlan` Python API, please have a look at {doc}`../flightplan_docs`.
 
   - Be mindful of the standard elements (ec_under, ec_track, c_north, c_mid, c_south)
   - Be mindful of the general rule of flying the circles after the transect, this can be important to ensure we have enough time to get ATC permission for the circle and drops.


### PR DESCRIPTION
This PR:
* adds more links to Python FlightPlan docs, fixes #387 
* improves typography of the flight plan howto page