### PR TITLE
Changed quicklook order and renaming

### DIFF
--- a/orcestra_book/reports/HALO-20240827a.md
+++ b/orcestra_book/reports/HALO-20240827a.md
@@ -197,13 +197,13 @@ HAMP EC underpass
 ```
 
 ```{card}
-%:img-top: ../figures/HALO-20240827a/hamp_radar_ec_under_HALO-20240827a.png
-Radar during EarthCARE underpass
+:img-top: ../figures/HALO-20240827a/HALO_20240827a_KT19.png
+KT-19 Timeseries of brightness temperature.
 ```
 
 ```{card}
-:img-top: ../figures/HALO-20240827a/HALO_20240827a_KT19.png
-KT-19 Timeseries of brightness temperature.
+%:img-top: ../figures/HALO-20240827a/hamp_radar_ec_under_HALO-20240827a.png
+Radar during EarthCARE underpass
 ```
 
 ```{card}

--- a/orcestra_book/reports/HALO-20240829a.md
+++ b/orcestra_book/reports/HALO-20240829a.md
@@ -142,7 +142,6 @@ Dropsondes: Circle mean profiles
 
 ```{card}
 :img-top: ../figures/HALO-20240829a/HALO_20240829a_KT-19.png
-```{card}
 
 KT-19: brightness temperature and cloud flag from KT19.
 ```

--- a/orcestra_book/reports/HALO-20240829a.md
+++ b/orcestra_book/reports/HALO-20240829a.md
@@ -144,7 +144,7 @@ Dropsondes: Circle mean profiles
 :img-top: ../figures/HALO-20240829a/HALO_20240829a_KT-19.png
 ```{card}
 
-Velox: brightness temperature and cloud flag from KT19.
+KT-19: brightness temperature and cloud flag from KT19.
 ```
 
 ```{card}

--- a/orcestra_book/reports/HALO-20240831a.md
+++ b/orcestra_book/reports/HALO-20240831a.md
@@ -139,9 +139,9 @@ Dropsondes
 ```
 
 ```{card}
-:img-top: ../figures/HALO-20240831a/HALO_20240831a_KT-19.png
+:img-top: ../figures/HALO-20240831a/HALO-20240831a-SMART_Quicklook.png
 
-Velox: brightness temperature and cloud flag from KT19.
+SMART timeseries.
 ```
 
 ```{card}
@@ -150,9 +150,9 @@ VELOX broadband channel with EC underpass
 ```
 
 ```{card}
-:img-top: ../figures/HALO-20240831a/HALO-20240831a-SMART_Quicklook.png
+:img-top: ../figures/HALO-20240831a/HALO_20240831a_KT-19.png
 
-SMART timeseries.
+KT-19 brightness temperature and cloud flag.
 ```
 
 ```{card}

--- a/orcestra_book/reports/HALO-20240903a.md
+++ b/orcestra_book/reports/HALO-20240903a.md
@@ -202,6 +202,7 @@ HAMP EC underpass
 :img-top: ../figures/HALO-20240903a/HALO_20240903a_KT-19.png
 KT-19 Timeseries of brightness temperature.
 ```
+
 ```{card}
 %:img-top: ../figures/HALO-20240903a/hamp_radar_ec_under_HALO-20240903a.png
 Radar during EarthCARE underpass

--- a/orcestra_book/reports/HALO-20240903a.md
+++ b/orcestra_book/reports/HALO-20240903a.md
@@ -199,13 +199,12 @@ HAMP EC underpass
 ```
 
 ```{card}
-%:img-top: ../figures/HALO-20240903a/hamp_radar_ec_under_HALO-20240903a.png
-Radar during EarthCARE underpass
-```
-
-```{card}
 :img-top: ../figures/HALO-20240903a/HALO_20240903a_KT-19.png
 KT-19 Timeseries of brightness temperature.
+```
+```{card}
+%:img-top: ../figures/HALO-20240903a/hamp_radar_ec_under_HALO-20240903a.png
+Radar during EarthCARE underpass
 ```
 
 ```{card}

--- a/orcestra_book/reports/HALO-20240907a.md
+++ b/orcestra_book/reports/HALO-20240907a.md
@@ -252,6 +252,7 @@ SMART
 :img-top: ../figures/HALO-20240907a/QL_VELOX_HALO_20240907a.jpg
 VELOX broadband channel with EC underpass
 ```
+
 ```{card}
 :img-top: ../figures/HALO-20240907a/0907-wales-3d.jpg
 WALES (3D backscatter)


### PR DESCRIPTION
bring quicklooks in alphabetical order.
changed figure caption of from velox to kt-10

in one instance I might have typed a comment like: renamed velox to hamp. it should be velox to kt-19. sorry. 