### PR TITLE
Remove category 'c_atr' from flight plan of HALO-20240909a

### DIFF
--- a/orcestra_book/plans/HALO-20240909a.md
+++ b/orcestra_book/plans/HALO-20240909a.md
@@ -1,6 +1,6 @@
 ---
 arrival_airport: TBPB
-categories: [ec_under, ec_track, c_north, c_mid, c_south, c_atr]
+categories: [ec_under, ec_track, c_north, c_mid, c_south]
 crew:
 - job: PI
   name: "Silke Gro\xDF"


### PR DESCRIPTION
The flight plan for flight `HALO-20240909a` accidentally included the category `c_atr`, which cannot be flown on Barbados. This is corrected by this MR. In the flight report, `c_atr` is already removed.

This closes #439 