### PR TITLE
Flight Plan for HALO-20240919a

### DIFF
--- a/orcestra_book/plans/HALO-20240919a.md
+++ b/orcestra_book/plans/HALO-20240919a.md
@@ -1,0 +1,82 @@
+---
+arrival_airport: TBPB
+categories: [ec_under, ec_track, c_north, c_mid, pace_under, meteor]
+crew:
+- job: PI
+  name: Clara Bayley
+- job: WALES
+  name: Sabrina Zechlau
+- job: HAMP
+  name: Raphaela Vogel
+- job: Dropsondes
+  name: Helene Glöckner
+- job: Smart/VELOX
+  name: Patrizia Schoch
+- job: SpecMACS
+  name: Anna Weber
+- job: Flight Documentation
+  name: Chelsea Nam
+- job: Ground contact
+  name: Julia Windmiller and Janina Boemeke
+departure_airport: TBPB
+flight_id: HALO-20240919a
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+orphan: true
+platform: HALO
+takeoff: '2024-09-16 10:35:00Z'
+landing: '2024-09-16 19:55:00Z'
+---
+
+
+{logo}`PERCUSION`
+
+# Flight plan - {front}`flight_id`
+
+```{badges}
+```
+
+## Crew
+
+```{crew}
+```
+
+## Flight plan
+
+```{code-cell} ipython3
+:tags: [hide-input]
+# Define HALO flight and crew
+aircraft = "HALO"
+flight_time = datetime(2024, 9, 19, 10, 30, 0)
+flight_id = f"{aircraft}-{flight_time.strftime('%Y%m%d')}a"
+crew = {
+    'Mission PI': 'Clara Bayley',
+    'DropSondes': 'Helene Glöckner',
+    'HAMP': 'Raphaela Vogel',
+    'SMART/VELOX': 'Patrizia Schoch',
+    'SpecMACS': 'tbc',
+    'WALES' : 'Sabrina Zechlau',
+    'Flight Documentation': 'Chelsea Nam',
+    'Ground Support': 'Julia Windmiller'
+}
+```
+
+```{code-cell} ipython3
+:tags: [hide-input]
+```
+
+```{code-cell} ipython3
+:tags: [hide-input]
+```
+
+```{code-cell} ipython3
+:tags: [hide-input]
+```
+
+

--- a/orcestra_book/plans/HALO-20240919a.md
+++ b/orcestra_book/plans/HALO-20240919a.md
@@ -63,7 +63,7 @@ crew = {
     'DropSondes': 'Helene Glöckner',
     'HAMP': 'Raphaela Vogel',
     'SMART/VELOX': 'Patrizia Schoch',
-    'SpecMACS': 'tbc',
+    'SpecMACS': 'Anna Weber',
     'WALES' : 'Sabrina Zechlau',
     'Flight Documentation': 'Chelsea Nam',
     'Ground Support': 'Julia Windmiller'

--- a/orcestra_book/plans/HALO-20240919a.md
+++ b/orcestra_book/plans/HALO-20240919a.md
@@ -51,8 +51,10 @@ landing: '2024-09-16 19:55:00Z'
 
 ```{code-cell} ipython3
 :tags: [hide-input]
-import datetime
+from datetime import datetime
 # Define HALO flight and crew
+from datetime import datetime
+
 aircraft = "HALO"
 flight_time = datetime(2024, 9, 19, 10, 30, 0)
 flight_id = f"{aircraft}-{flight_time.strftime('%Y%m%d')}a"
@@ -70,12 +72,187 @@ crew = {
 
 ```{code-cell} ipython3
 :tags: [hide-input]
+# Define some fixed values
+import easygems.healpix as egh
+import intake
+import numpy as np
+import orcestra.sat
+from orcestra.flightplan import tbpb
+
+airport = tbpb
+radius = 72e3*1.852
+
+sat_fcst_date = "2024-09-15" # date to get satelite forecast(s) from
+ec_time_slice = slice(f"{flight_time:%Y-%m-%d} 17:40", f"{flight_time:%Y-%m-%d} 17:47") # timeslice of forecast(s) to use
+pace_time_slice = slice(f"{flight_time:%Y-%m-%d} 16:19", f"{flight_time:%Y-%m-%d} 16:24") # timeslice of forecast(s) to use
+
+ifs_fcst_time = "2024-09-15" # date to get IFS forecast(s) from
+ifs_fcst_time = np.datetime64(ifs_fcst_time + "T12:00:00")
+
+# Load satellite tracks
+print(f"SATELITE TRACK FORECAST FROM: {sat_fcst_date} FOR FLIGHT DAY: {flight_time:%Y-%m-%d}")
+ec_track = orcestra.sat.SattrackLoader("EARTHCARE", sat_fcst_date, kind="PRE", roi="BARBADOS") \
+    .get_track_for_day(f"{flight_time:%Y-%m-%d}") \
+        .sel(time=ec_time_slice)
+
+pace_track = orcestra.sat.pace_track_loader() \
+    .get_track_for_day(f"{flight_time:%Y-%m-%d}") \
+        .sel(time=pace_time_slice)
+
+# Load IFS forecast
+cat = "https://tcodata.mpimet.mpg.de/internal.yaml"
+ifs_ds = intake.open_catalog(cat).HIFS(datetime=ifs_fcst_time).to_dask().pipe(egh.attach_coords)
 ```
 
 ```{code-cell} ipython3
 :tags: [hide-input]
+# Create the flight plan
+from HALO_20240919a_plan import *
+from orcestra.flightplan import LatLon, point_on_track, IntoCircle, FlightPlan
+
+# Create waypoints for flight path
+meteor = LatLon(10.65, -49.5).assign(label="meteor")
+pace_ec_overlap = LatLon(16.7792, -53.4286).assign(label="meteor")
+
+pace_start = point_on_track(pace_track, lat=11.35).assign(label="pace_start") # c3
+pace_end = point_on_track(pace_track, lat=pace_ec_overlap.lat).assign(label = "pace_end") # c3
+dist5mins = 220 * 5 * 60
+pace_end_t5mins = pace_end.course(geod_azi(pace_end, pace_start), dist5mins).assign(label="t-5")
+pace_under = point_on_track(pace_track, lat=pace_end_t5mins.lat, with_time=True).assign(label="pace_under", note="meet PACE") # SHOULD
+
+ec_start = point_on_track(ec_track, lat=pace_ec_overlap.lat).assign(label = "ec_start") # c3
+ec_end = point_on_track(ec_track, lat=11.88).assign(label = "ec_end") # c4 and c5
+dist15mins = 220 * 15 * 60
+ec_start_t15mins = ec_start.course(geod_azi(ec_start, ec_start), dist15mins).assign(label="t+15")
+ec_under = point_on_track(ec_track, lat=ec_start_t15mins.lat).assign(label="ec_under", note="meet EarthCARE") # MUST
+
+circ_1 = airport.course(geod_azi(airport, meteor), 1400000).assign(label="c1")
+circ_3 = centre_from_tangent(meteor, pace_start, radius, 0).assign(label="c3")
+circ_2 = circ_1.towards(circ_3, fraction=1/2).assign(label="c2")
+p2 = circ_2.towards(circ_3, distance=radius)
+circ_4 = centre_from_tangent(ec_end, pace_end, radius, 180).assign(label="c4")
+circ_5 = circ_3.towards(airport, distance=geod_dist(circ_1, circ_2)).assign(label="c5")
+
+# Additional Waypoints
+extra_waypoints = []
+
+# Define Flight Paths
+waypoints = [
+    airport.assign(fl=0),
+    meteor.assign(fl=410),
+    IntoCircle(circ_1.assign(fl=410), radius,  angle=360), # clockwise (optional)
+    meteor.assign(fl=410),
+    p2.assign(fl=410),
+    IntoCircle(circ_2.assign(fl=410), radius,  angle=-360), # anti-clockwise (optional)
+    IntoCircle(circ_3.assign(fl=410), radius,  angle=-360), # ANTI-CLOCKWISE
+    pace_start.assign(fl=410),
+    pace_under.assign(fl=410),
+    pace_end.assign(fl=410),
+    IntoCircle(circ_4.assign(fl=410), radius,  angle=-360), # anti-clockwise (preferable)
+    ec_start.assign(fl=410),
+    ec_under.assign(fl=410),
+    ec_end.assign(fl=410),
+    IntoCircle(circ_5.assign(fl=410), radius,  angle=360), # clockwise (optional)
+    airport.assign(fl=0),
+]
+
+plan = FlightPlan(path=waypoints, flight_id=flight_id, extra_waypoints=extra_waypoints, crew=crew, aircraft=aircraft)
+
+msg = f"Flight ID: {plan.flight_id}\n" \
+    + f"Take-off: {plan.takeoff_time:%H:%M %Z}\n" \
+    + f"Landing:  {plan.landing_time:%H:%M %Z}\n" \
+    + f"Duration: {plan.duration}"
+print(msg)
 ```
 
 ```{code-cell} ipython3
 :tags: [hide-input]
+
+from HALO_20240919a_plan import plot_flight_plan_satellite_forecast
+from orcestra.flightplan import plot_cwv
+
+figsize=(14, 8)
+worldfirs_json = "worldfirs.json"
+lon_min, lon_max, lat_min, lat_max = -65, -5, -5, 25
+domain_lonlat = [lon_min, lon_max, lat_min, lat_max]
+
+def plot_ifs_cwv_forecast(fig, ax, ifs_ds, flight_time, levels=None):
+    cwv_flight_time = ifs_ds["tcwv"].sel(time=flight_time, method="nearest")
+    plot_cwv(cwv_flight_time, ax=ax, levels=levels)
+
+plot_cwv_kwargs = {
+    "flight_time": flight_time,
+    "levels": [45, 50, 55, 60]
+    }
+
+fig, ax = plot_flight_plan_satellite_forecast(figsize,
+                                    flight_time,
+                                    plan,
+                                    domain_lonlat,
+                                    is_ec_track=True,
+                                    ec_track=ec_track,
+                                    is_pace_track=True,
+                                    pace_track=pace_track,
+                                    forecast_overlay=True,
+                                    ifs_ds=ifs_ds,
+                                    ifs_fcst_time=ifs_fcst_time,
+                                    forecast_title_label="CWV",
+                                    plot_forecast_func=plot_ifs_cwv_forecast,
+                                    plot_forecast_kwargs=plot_cwv_kwargs,
+                                    atc_zones=True,
+                                    worldfirs_json=worldfirs_json,
+                                    is_meteor=True,
+                                    meteor=meteor)
+```
+
+```{code-cell} ipython3
+:tags: [hide-input]
+import sfc_winds_weather_briefing as sfc_winds
+
+figsize=(16, 9)
+worldfirs_json = "worldfirs.json"
+lon_min, lon_max, lat_min, lat_max = -65, -5, -5, 25
+domain_lonlat = [lon_min, lon_max, lat_min, lat_max]
+
+def plot_ifs_sfc_winds_forecast(fig, ax, ifs_ds, domain_lonlat, flight_time):
+    u10m = ifs_ds["10u"].sel(time=flight_time, method="nearest")
+    v10m = ifs_ds["10v"].sel(time=flight_time, method="nearest")
+    windspeed_10m = np.sqrt(u10m**2 + v10m**2)
+    sfc_winds._windspeed_plot(windspeed_10m, fig, ax)
+    sfc_winds._wind_direction_plot(u10m, v10m, ax, domain_lonlat)
+    sfc_winds._windspeed_contour(windspeed_10m, ax)
+    sfc_winds._draw_confluence_contour(v10m, ax)
+
+plot_ifs_sfc_winds_kwargs = {
+    "domain_lonlat": domain_lonlat,
+    "flight_time": flight_time,
+}
+
+fig, ax = plot_flight_plan_satellite_forecast(figsize,
+                                    flight_time,
+                                    plan,
+                                    domain_lonlat,
+                                    is_ec_track=True,
+                                    ec_track=ec_track,
+                                    is_pace_track=True,
+                                    pace_track=pace_track,
+                                    forecast_overlay=True,
+                                    ifs_ds=ifs_ds,
+                                    ifs_fcst_time=ifs_fcst_time,
+                                    forecast_title_label="10m Winds",
+                                    plot_forecast_func=plot_ifs_sfc_winds_forecast,
+                                    plot_forecast_kwargs=plot_ifs_sfc_winds_kwargs,
+                                    atc_zones=True,
+                                    worldfirs_json=worldfirs_json,
+                                    is_meteor=True,
+                                    meteor=meteor)
+```
+
+```{code-cell} ipython3
+:tags: [hide-input]
+from orcestra.flightplan import vertical_preview
+
+vertical_preview(waypoints)
+plan.show_details()
+plan.export()
 ```

--- a/orcestra_book/plans/HALO-20240919a.md
+++ b/orcestra_book/plans/HALO-20240919a.md
@@ -207,7 +207,7 @@ fig, ax = plot_flight_plan_satellite_forecast(figsize,
 
 ```{code-cell} ipython3
 :tags: [hide-input]
-import sfc_winds_weather_briefing as sfc_winds
+import HALO_20240919a_sfc_winds as sfc_winds
 
 figsize=(16, 9)
 worldfirs_json = "worldfirs.json"

--- a/orcestra_book/plans/HALO-20240919a.md
+++ b/orcestra_book/plans/HALO-20240919a.md
@@ -51,6 +51,7 @@ landing: '2024-09-16 19:55:00Z'
 
 ```{code-cell} ipython3
 :tags: [hide-input]
+import datetime
 # Define HALO flight and crew
 aircraft = "HALO"
 flight_time = datetime(2024, 9, 19, 10, 30, 0)
@@ -78,5 +79,3 @@ crew = {
 ```{code-cell} ipython3
 :tags: [hide-input]
 ```
-
-

--- a/orcestra_book/plans/HALO-20240919a.md
+++ b/orcestra_book/plans/HALO-20240919a.md
@@ -81,6 +81,7 @@ from orcestra.flightplan import tbpb
 
 airport = tbpb
 radius = 72e3*1.852
+halo_speed = 238.5 # at FL450 [m/s]
 
 sat_fcst_date = "2024-09-15" # date to get satelite forecast(s) from
 ec_time_slice = slice(f"{flight_time:%Y-%m-%d} 17:40", f"{flight_time:%Y-%m-%d} 17:47") # timeslice of forecast(s) to use
@@ -107,24 +108,24 @@ ifs_ds = intake.open_catalog(cat).HIFS(datetime=ifs_fcst_time).to_dask().pipe(eg
 ```{code-cell} ipython3
 :tags: [hide-input]
 # Create the flight plan
-from HALO_20240919a_plan import *
+from HALO_20240919a_plan import geod_azi, geod_dist, centre_from_tangent
 from orcestra.flightplan import LatLon, point_on_track, IntoCircle, FlightPlan
 
-# Create waypoints for flight path
+# Create points for flight path
 meteor = LatLon(10.65, -49.5).assign(label="meteor")
-pace_ec_overlap = LatLon(16.7792, -53.4286).assign(label="meteor")
+pace_ec_overlap = LatLon(16.7792, -53.4286).assign(label="pace_ec_cross")
 
-pace_start = point_on_track(pace_track, lat=11.35).assign(label="pace_start") # c3
-pace_end = point_on_track(pace_track, lat=pace_ec_overlap.lat).assign(label = "pace_end") # c3
-dist5mins = 220 * 5 * 60
-pace_end_t5mins = pace_end.course(geod_azi(pace_end, pace_start), dist5mins).assign(label="t-5")
-pace_under = point_on_track(pace_track, lat=pace_end_t5mins.lat, with_time=True).assign(label="pace_under", note="meet PACE") # SHOULD
+pace_start = point_on_track(pace_track, lat=11.35).assign(label="pace_start")
+pace_end = point_on_track(pace_track, lat=pace_ec_overlap.lat).assign(label = "pace_end")
+dist5mins = halo_speed * 5 * 60
+pace_end_t5mins = pace_end.course(geod_azi(pace_end, pace_start), dist5mins)
+pace_under = point_on_track(pace_track, lat=pace_end_t5mins.lat, with_time=True).assign(label="pace_under", note="meet PACE")
 
-ec_start = point_on_track(ec_track, lat=pace_ec_overlap.lat).assign(label = "ec_start") # c3
-ec_end = point_on_track(ec_track, lat=11.88).assign(label = "ec_end") # c4 and c5
-dist15mins = 220 * 15 * 60
-ec_start_t15mins = ec_start.course(geod_azi(ec_start, ec_start), dist15mins).assign(label="t+15")
-ec_under = point_on_track(ec_track, lat=ec_start_t15mins.lat).assign(label="ec_under", note="meet EarthCARE") # MUST
+ec_start = point_on_track(ec_track, lat=pace_ec_overlap.lat).assign(label = "ec_start")
+ec_end = point_on_track(ec_track, lat=11.88).assign(label = "ec_end")
+dist15mins = halo_speed * 15 * 60
+ec_start_t15mins = ec_start.course(geod_azi(ec_start, ec_start), dist15mins)
+ec_under = point_on_track(ec_track, lat=ec_start_t15mins.lat).assign(label="ec_under", note="meet EarthCARE")
 
 circ_1 = airport.course(geod_azi(airport, meteor), 1400000).assign(label="c1")
 circ_3 = centre_from_tangent(meteor, pace_start, radius, 0).assign(label="c3")
@@ -133,31 +134,32 @@ p2 = circ_2.towards(circ_3, distance=radius)
 circ_4 = centre_from_tangent(ec_end, pace_end, radius, 180).assign(label="c4")
 circ_5 = circ_3.towards(airport, distance=geod_dist(circ_1, circ_2)).assign(label="c5")
 
-# Additional Waypoints
-extra_waypoints = []
-
-# Define Flight Paths
+# Define Waypoints
+fl1, fl2, fl3 = 410, 430, 450
 waypoints = [
     airport.assign(fl=0),
-    meteor.assign(fl=410),
-    IntoCircle(circ_1.assign(fl=410), radius,  angle=360), # clockwise (optional)
-    meteor.assign(fl=410),
-    p2.assign(fl=410),
-    IntoCircle(circ_2.assign(fl=410), radius,  angle=-360), # anti-clockwise (optional)
-    IntoCircle(circ_3.assign(fl=410), radius,  angle=-360), # ANTI-CLOCKWISE
-    pace_start.assign(fl=410),
-    pace_under.assign(fl=410),
-    pace_end.assign(fl=410),
-    IntoCircle(circ_4.assign(fl=410), radius,  angle=-360), # anti-clockwise (preferable)
-    ec_start.assign(fl=410),
-    ec_under.assign(fl=410),
-    ec_end.assign(fl=410),
-    IntoCircle(circ_5.assign(fl=410), radius,  angle=360), # clockwise (optional)
+    meteor.assign(fl=fl1),
+    IntoCircle(circ_1.assign(fl=fl2), radius,  angle=360), # clockwise (optional)
+    meteor.assign(fl=fl2),
+    p2.assign(fl=fl2),
+    IntoCircle(circ_2.assign(fl=fl2), radius,  angle=-360), # anti-clockwise (optional)
+    IntoCircle(circ_3.assign(fl=fl3), radius,  angle=-360), # ANTI-CLOCKWISE
+    pace_start.assign(fl=fl3),
+    pace_under.assign(fl=fl3),
+    pace_end.assign(fl=fl3),
+    IntoCircle(circ_4.assign(fl=fl3), radius,  angle=-360), # anti-clockwise (preferable)
+    ec_start.assign(fl=fl3),
+    ec_under.assign(fl=fl3),
+    ec_end.assign(fl=fl3),
+    IntoCircle(circ_5.assign(fl=fl3), radius,  angle=360), # clockwise (optional)
     airport.assign(fl=0),
 ]
 
-plan = FlightPlan(path=waypoints, flight_id=flight_id, extra_waypoints=extra_waypoints, crew=crew, aircraft=aircraft)
+# Additional Waypoints
+extra_waypoints = []
 
+# FlightPlan and short statement
+plan = FlightPlan(path=waypoints, flight_id=flight_id, extra_waypoints=extra_waypoints, crew=crew, aircraft=aircraft)
 msg = f"Flight ID: {plan.flight_id}\n" \
     + f"Take-off: {plan.takeoff_time:%H:%M %Z}\n" \
     + f"Landing:  {plan.landing_time:%H:%M %Z}\n" \
@@ -167,7 +169,6 @@ print(msg)
 
 ```{code-cell} ipython3
 :tags: [hide-input]
-
 from HALO_20240919a_plan import plot_flight_plan_satellite_forecast
 from orcestra.flightplan import plot_cwv
 
@@ -253,6 +254,10 @@ fig, ax = plot_flight_plan_satellite_forecast(figsize,
 from orcestra.flightplan import vertical_preview
 
 vertical_preview(waypoints)
+```
+
+```{code-cell} ipython3
+:tags: [hide-input]
 plan.show_details()
 plan.export()
 ```

--- a/orcestra_book/plans/HALO-20240919a.md
+++ b/orcestra_book/plans/HALO-20240919a.md
@@ -130,7 +130,6 @@ ec_under = point_on_track(ec_track, lat=ec_start_t15mins.lat).assign(label="ec_u
 circ_1 = airport.course(geod_azi(airport, meteor), 1400000).assign(label="c1")
 circ_3 = centre_from_tangent(meteor, pace_start, radius, 0).assign(label="c3")
 circ_2 = circ_1.towards(circ_3, fraction=1/2).assign(label="c2")
-p2 = circ_2.towards(circ_3, distance=radius)
 circ_4 = centre_from_tangent(ec_end, pace_end, radius, 180).assign(label="c4")
 circ_5 = circ_3.towards(airport, distance=geod_dist(circ_1, circ_2)).assign(label="c5")
 
@@ -141,8 +140,7 @@ waypoints = [
     meteor.assign(fl=fl1),
     IntoCircle(circ_1.assign(fl=fl2), radius,  angle=360), # clockwise (optional)
     meteor.assign(fl=fl2),
-    p2.assign(fl=fl2),
-    IntoCircle(circ_2.assign(fl=fl2), radius,  angle=-360), # anti-clockwise (optional)
+    IntoCircle(circ_2.assign(fl=fl2), radius,  angle=-360, enter=90), # anti-clockwise (optional)
     IntoCircle(circ_3.assign(fl=fl3), radius,  angle=-360), # ANTI-CLOCKWISE
     pace_start.assign(fl=fl3),
     pace_under.assign(fl=fl3),
@@ -156,7 +154,8 @@ waypoints = [
 ]
 
 # Additional Waypoints
-extra_waypoints = []
+p2 = circ_2.towards(circ_3, distance=radius)
+extra_waypoints = [p2.assign(fl=fl2),]
 
 # FlightPlan and short statement
 plan = FlightPlan(path=waypoints, flight_id=flight_id, extra_waypoints=extra_waypoints, crew=crew, aircraft=aircraft)

--- a/orcestra_book/plans/HALO_20240919a_plan.py
+++ b/orcestra_book/plans/HALO_20240919a_plan.py
@@ -1,0 +1,125 @@
+''' helper functions for rendering HALO-20240919a flight plan'''
+
+def geod_azi(latlon1, latlon2):
+    import pyproj
+    geod = pyproj.Geod(ellps="WGS84")
+
+    return geod.inv(latlon1.lon, latlon1.lat, latlon2.lon, latlon2.lat)[0]
+
+def geod_dist(latlon1, latlon2):
+    import pyproj
+    geod = pyproj.Geod(ellps="WGS84")
+
+    return geod.inv(latlon1.lon, latlon1.lat, latlon2.lon, latlon2.lat)[2]
+
+def centre_from_tangent(latlon1, latlon2, radius, add_angle=0):
+    import pyproj
+    geod = pyproj.Geod(ellps="WGS84")
+ 
+    az12, az21, dist = geod.inv(latlon1.lon, latlon1.lat, latlon2.lon, latlon2.lat)
+    azi_angle = az12 + add_angle
+
+    return latlon2.course(azi_angle, radius)
+
+def plot_satellite_track(ax, lon, lat, c, ls, label):
+
+    ax.plot(lon, lat, c=c, ls=ls, label=label)
+
+    for i in range(1, len(lon), 10):  # Adjust the step to control the number of arrows
+        ax.annotate('', xy=(lon[i], lat[i]), xytext=(lon[i-1], lat[i-1]),
+                    arrowprops=dict(arrowstyle="->", color=c))
+
+def plot_forcast_overlay(fig, ax, ifs_ds, ifs_fcst_time, title_label, plot_func, plot_func_kwargs):
+    from datetime import datetime
+
+    plot_func(fig, ax, ifs_ds, **plot_func_kwargs)
+
+    ifs_fcst_time_str = ifs_fcst_time.astype(datetime).strftime("%Y-%m-%d %H:%M:%S")
+    title = ax.get_title()+f"\n({title_label} forecasted on {ifs_fcst_time_str})"
+    ax.set_title(f"{title}", fontsize=15, y=1.1)
+
+def plot_atc_zones(ax, worldfirs_json):
+    import topojson
+    import json
+    import cartopy.crs as ccrs
+
+    with open(worldfirs_json, 'r') as f:
+        data = json.load(f)
+
+    # parse topojson file using `object_name`
+    topo = topojson.Topology(data, object_name="data")
+    firs = topo.to_gdf()
+    kwargs = {
+        "color": 'k',
+        "linestyle": 'dashed',
+        "linewidth": 0.3
+    }
+    for i, row in firs.iterrows():
+        for geom in getattr(row.geometry.boundary, "geoms", [row.geometry.boundary]):
+            lon, lat = zip(*list(geom.coords))
+            if i == 0:
+                kwargs["label"] = "ATC zones"
+                kwargs["alpha"] = 1.0
+            else:
+                kwargs["label"] = None
+                kwargs["alpha"] = 0.4
+            ax.plot(lon, lat, transform=ccrs.PlateCarree(), **kwargs)
+
+def plot_flight_plan_satellite_forecast(figsize,
+                                        flight_time,
+                                        plan,
+                                        domain_lonlat,
+                                        is_ec_track=False,
+                                        ec_track=None,
+                                        is_pace_track=False,
+                                        pace_track=None,
+                                        forecast_overlay=False,
+                                        ifs_ds=None,
+                                        ifs_fcst_time=None,
+                                        forecast_title_label=None,
+                                        plot_forecast_func=None,
+                                        plot_forecast_kwargs=None,
+                                        atc_zones=False,
+                                        worldfirs_json=None,
+                                        is_meteor=False,
+                                        meteor=None):
+    import matplotlib.pyplot as plt
+    import cartopy.crs as ccrs
+    from orcestra.flightplan import plot_path
+
+    fig = plt.figure(figsize=figsize)
+    ax = plt.axes(projection=ccrs.PlateCarree())
+
+    ax.set_extent(domain_lonlat, crs=ccrs.PlateCarree())
+    ax.coastlines(alpha=1.0)
+    ax.gridlines(draw_labels=True, dms=True, x_inline=False, y_inline=False, alpha=0.25)
+
+    # plot EarthCARE track and flight plan
+    if is_ec_track:
+        plot_satellite_track(ax, ec_track.lon, ec_track.lat, 'green', 'dotted', "EarthCARE")
+    if is_pace_track:
+        plot_satellite_track(ax, pace_track.lon, pace_track.lat, 'purple', 'dotted', "PACE")
+        plt.fill_betweenx(pace_track.lat, pace_track.lon, pace_track.lon+1,color='violet',alpha=0.2)
+        plt.fill_betweenx(pace_track.lat, pace_track.lon, pace_track.lon-1,color='violet',alpha=0.2)
+
+    # (optional) plot CWV overlay
+    if (forecast_overlay):
+        plot_forcast_overlay(fig, ax, ifs_ds, ifs_fcst_time, forecast_title_label, plot_forecast_func, plot_forecast_kwargs)
+
+    # (optional) plot ATC zones
+    if (atc_zones):
+        plot_atc_zones(ax, worldfirs_json)
+
+    if (is_meteor):
+        ax.scatter(meteor.lon, meteor.lat, color="crimson", marker="x")                                    
+        ax.annotate('METEOR', xy=(meteor.lon, meteor.lat), xytext=(meteor.lon+3, meteor.lat-4.5),
+                arrowprops=dict(color='crimson', shrink=0.05, width=0.5, headwidth=0),
+                color="crimson")
+
+    plot_path(plan, ax, color="C1")
+
+    ax.legend(loc="upper left", bbox_to_anchor=(-0.035, 1.24), frameon=False, fontsize=12)
+    title = f"{flight_time}\n"+ax.get_title()
+    ax.set_title(title, fontsize=15, y=1.1)
+
+    return fig, ax

--- a/orcestra_book/plans/HALO_20240919a_sfc_winds.py
+++ b/orcestra_book/plans/HALO_20240919a_sfc_winds.py
@@ -1,0 +1,83 @@
+"""generates surface wind speed plots with
+    low wind speed regions identified using ECMWF IFS.
+    Functions copied from sfc_winds.py from orcestra
+    weather briefing repository"""
+
+import easygems.healpix as egh
+import numpy as np
+import healpy as hp
+import xarray as xr
+
+SPEED_THRESHOLD = 3  # m/s
+SPEED_MAX = 15  # m/s
+SPEED_MIN = 0  # m/s
+SPEED_COLORMAP = "YlGn"
+MESH_GRID_SIZE = 50
+QUIVER_SKIP = 4
+
+def _windspeed_contour(windspeed_10m, ax):
+    im = egh.healpix_contour(
+        windspeed_10m,
+        ax=ax,
+        levels=[SPEED_THRESHOLD],
+        colors="r",
+    )
+    ax.clabel(im, inline=True, fontsize=12, colors="r", fmt="%d")
+
+def _draw_confluence_contour(v10m, ax):
+    im = egh.healpix_contour(
+        v10m,
+        ax=ax,
+        levels=[0],
+        colors="gray",
+        linewidths = 1.2
+    )
+    ax.clabel(im, inline=True, fontsize=10, colors="gray", fmt="%d")
+
+
+def _windspeed_plot(windspeed_10m, fig, ax):
+    im = egh.healpix_show(
+        windspeed_10m,
+        method="linear",
+        cmap=SPEED_COLORMAP,
+        vmin=SPEED_MIN,
+        vmax=SPEED_MAX,
+        ax=ax,
+    )
+    fig.colorbar(im, label="10m wind speed / m s$^{-1}$", shrink=0.8)
+
+
+def _wind_direction_plot(u10m, v10m, ax, domain_lonlat):
+    lon_min, lon_max, lat_min, lat_max = domain_lonlat
+    lon1 = np.linspace(lon_min, lon_max, MESH_GRID_SIZE)
+    lat1 = np.linspace(lat_min, lat_max, MESH_GRID_SIZE)
+    pix = xr.DataArray(
+        hp.ang2pix(
+            u10m.crs.healpix_nside,
+            *np.meshgrid(lon1, lat1),
+            nest=True,
+            lonlat=True,
+        ),
+        coords=(("lat1", lat1), ("lon1", lon1)),
+    )
+    Q0 = ax.quiver(
+        lon1[::QUIVER_SKIP],
+        lat1[::QUIVER_SKIP],
+        u10m.isel(cell=pix)[::QUIVER_SKIP, ::QUIVER_SKIP],
+        v10m.isel(cell=pix)[::QUIVER_SKIP, ::QUIVER_SKIP],
+        color="black",
+        pivot="middle",
+        scale_units="inches",
+        width=0.003,
+        scale=20,
+    )
+    ax.quiverkey(
+        Q0,
+        0.95,
+        1.05,
+        10,
+        r"$10 \frac{m}{s}$",
+        labelpos="E",
+        coordinates="axes",
+        animated=True,
+    )


### PR DESCRIPTION
- Adds markdown file for HALO-20240919a flight plan. Markdown python cells have dependencies on two python scripts also added: HALO_20240919a_sfc_winds.py and HALO_20240919a_plan.py

Current issues:
- HALO_20240919a_sfc_winds requires healpy but that's not part of the book's build environment
- HALO_20240919a_sfc_winds is a copy and paste of functions from [weather briefing's sfc_winds.py](https://github.com/orcestra-campaign/weather/blob/main/src/wblib/figures/internal/sfc_winds.py). Can we import that instead?
- plan.show_details() gives `TypeError: unsupported format string passed to NoneType.__format__` [now fixed]