### PR TITLE
add upcoming planned flights

### DIFF
--- a/orcestra_book/plans/HALO-20240919a.md
+++ b/orcestra_book/plans/HALO-20240919a.md
@@ -1,0 +1,50 @@
+---
+arrival_airport: TBPB
+categories: []
+crew:
+- job: PI
+  name: Clara Bayley
+- job: WALES
+  name: tbd
+- job: HAMP
+  name: tbd
+- job: Dropsondes
+  name: tbd
+- job: Smart/VELOX
+  name: tbd
+- job: SpecMACS
+  name: tbd
+- job: Flight Documentation
+  name: tbd
+- job: Ground contact
+  name: tbd
+departure_airport: TBPB
+flight_id: HALO-20240919a
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+landing: "2024-09-19T20:00:00Z"
+orphan: true
+platform: HALO
+takeoff: "2024-09-19T12:00:00Z"
+---
+
+{logo}`PERCUSION`
+
+# Flight plan - {front}`flight_id`
+
+```{badges}
+```
+
+## Crew
+
+```{crew}
+```
+
+## Flight plan
+

--- a/orcestra_book/plans/HALO-20240921a.md
+++ b/orcestra_book/plans/HALO-20240921a.md
@@ -1,0 +1,50 @@
+---
+arrival_airport: TBPB
+categories: []
+crew:
+- job: PI
+  name: Raphaela Vogel
+- job: WALES
+  name: tbd
+- job: HAMP
+  name: tbd
+- job: Dropsondes
+  name: tbd
+- job: Smart/VELOX
+  name: tbd
+- job: SpecMACS
+  name: tbd
+- job: Flight Documentation
+  name: tbd
+- job: Ground contact
+  name: tbd
+departure_airport: TBPB
+flight_id: HALO-20240921a
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+landing: "2024-09-21T20:00:00Z"
+orphan: true
+platform: HALO
+takeoff: "2024-09-21T12:00:00Z"
+---
+
+{logo}`PERCUSION`
+
+# Flight plan - {front}`flight_id`
+
+```{badges}
+```
+
+## Crew
+
+```{crew}
+```
+
+## Flight plan
+

--- a/orcestra_book/plans/HALO-20240923a.md
+++ b/orcestra_book/plans/HALO-20240923a.md
@@ -1,0 +1,50 @@
+---
+arrival_airport: TBPB
+categories: []
+crew:
+- job: PI
+  name: Theresa Mieslinger
+- job: WALES
+  name: tbd
+- job: HAMP
+  name: tbd
+- job: Dropsondes
+  name: tbd
+- job: Smart/VELOX
+  name: tbd
+- job: SpecMACS
+  name: tbd
+- job: Flight Documentation
+  name: tbd
+- job: Ground contact
+  name: tbd
+departure_airport: TBPB
+flight_id: HALO-20240923a
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+landing: "2024-09-23T20:00:00Z"
+orphan: true
+platform: HALO
+takeoff: "2024-09-23T12:00:00Z"
+---
+
+{logo}`PERCUSION`
+
+# Flight plan - {front}`flight_id`
+
+```{badges}
+```
+
+## Crew
+
+```{crew}
+```
+
+## Flight plan
+

--- a/orcestra_book/plans/HALO-20240924a.md
+++ b/orcestra_book/plans/HALO-20240924a.md
@@ -1,0 +1,50 @@
+---
+arrival_airport: TBPB
+categories: []
+crew:
+- job: PI
+  name: Anna Weber
+- job: WALES
+  name: tbd
+- job: HAMP
+  name: tbd
+- job: Dropsondes
+  name: tbd
+- job: Smart/VELOX
+  name: tbd
+- job: SpecMACS
+  name: tbd
+- job: Flight Documentation
+  name: tbd
+- job: Ground contact
+  name: tbd
+departure_airport: TBPB
+flight_id: HALO-20240924a
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+landing: "2024-09-24T20:00:00Z"
+orphan: true
+platform: HALO
+takeoff: "2024-09-24T12:00:00Z"
+---
+
+{logo}`PERCUSION`
+
+# Flight plan - {front}`flight_id`
+
+```{badges}
+```
+
+## Crew
+
+```{crew}
+```
+
+## Flight plan
+

--- a/orcestra_book/plans/HALO-20240926a.md
+++ b/orcestra_book/plans/HALO-20240926a.md
@@ -1,0 +1,50 @@
+---
+arrival_airport: TBPB
+categories: []
+crew:
+- job: PI
+  name: Jakob Deutloff
+- job: WALES
+  name: tbd
+- job: HAMP
+  name: tbd
+- job: Dropsondes
+  name: tbd
+- job: Smart/VELOX
+  name: tbd
+- job: SpecMACS
+  name: tbd
+- job: Flight Documentation
+  name: tbd
+- job: Ground contact
+  name: tbd
+departure_airport: TBPB
+flight_id: HALO-20240926a
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+landing: "2024-09-26T20:00:00Z"
+orphan: true
+platform: HALO
+takeoff: "2024-09-26T12:00:00Z"
+---
+
+{logo}`PERCUSION`
+
+# Flight plan - {front}`flight_id`
+
+```{badges}
+```
+
+## Crew
+
+```{crew}
+```
+
+## Flight plan
+

--- a/orcestra_book/plans/HALO-20240928a.md
+++ b/orcestra_book/plans/HALO-20240928a.md
@@ -1,0 +1,50 @@
+---
+arrival_airport: TBPB
+categories: []
+crew:
+- job: PI
+  name: Julia Windmiller
+- job: WALES
+  name: tbd
+- job: HAMP
+  name: tbd
+- job: Dropsondes
+  name: tbd
+- job: Smart/VELOX
+  name: tbd
+- job: SpecMACS
+  name: tbd
+- job: Flight Documentation
+  name: tbd
+- job: Ground contact
+  name: tbd
+departure_airport: TBPB
+flight_id: HALO-20240928a
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+landing: "2024-09-28T20:00:00Z"
+orphan: true
+platform: HALO
+takeoff: "2024-09-28T12:00:00Z"
+---
+
+{logo}`PERCUSION`
+
+# Flight plan - {front}`flight_id`
+
+```{badges}
+```
+
+## Crew
+
+```{crew}
+```
+
+## Flight plan
+


### PR DESCRIPTION
Some information about the upcoming flights is already available. This PR collects dates and PIs for those flights and adds them to the plans, such that the information is available at our well known central place. The PR will also fill the missing calendar entries.