### PR TITLE
Update HALO-20240921a.md: addition of flight categories

### DIFF
--- a/orcestra_book/plans/HALO-20240921a.md
+++ b/orcestra_book/plans/HALO-20240921a.md
@@ -1,6 +1,6 @@
 ---
 arrival_airport: TBPB
-categories: []
+categories: [ec_under, ec_track, c_mid, meteor]
 crew:
 - job: PI
   name: Raphaela Vogel


### PR DESCRIPTION
We fly three circles, but all of them in the "middle" of the ITCZ. So I just put c_mid. I wonder whether we should add new categories for these last flights with c_west, c_mid and c_east? Could be discussed.