### PR TITLE
Adds goes2go to the environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - fsspec!=0.9.0 # 0.9.0 has a bug which leads to incomplete reads via HTTP
   - geopandas
   - geopy
+  - goes2go
   - healpix
   - icalendar
   - intake-xarray


### PR DESCRIPTION
To be able to plot the flight track on the corresponding satellite image I am using the goes2go package. I use goes2go rather than NASA Worldview because it uses the long term storage of the data at AWS while Worldview only offers GOES data for the last 90 days.