### PR TITLE
Deletion of an erroneous note in the flight report of HALO-20240818a

### DIFF
--- a/orcestra_book/reports/HALO-20240818a.md
+++ b/orcestra_book/reports/HALO-20240818a.md
@@ -117,10 +117,6 @@ The large convective system in the center of the ITCZ did not reveal any structu
  - 16:57 Heading towards 2nd 40 NM circle; more convective structure visible; afterwards back to EC track and heading towards SAL
  - 19:10 Landing 
 
-```{note}
-Co-location with ATR and EarthCARE over an aerosol layer near SAL. Spectacular line of convection on southern edge toward the west.
-```
-
 ````{card-carousel} 2
 ```{card}
 :img-top: ../figures/HALO-20240818a/0818-crew.jpeg


### PR DESCRIPTION
The deleted note does not match the impressions of the flight, in particular flight HALO-20240818a did not have an ATR coordination. I suspect that the note stems from a copy and paste of the flight report of flight HALO-20240813a, which has an identical note.