### PR TITLE
Stop Scheduled Publish

### DIFF
--- a/.github/workflows/buildbook.yaml
+++ b/.github/workflows/buildbook.yaml
@@ -88,7 +88,7 @@ jobs:
 
   publish:
     needs: build
-    if: "always() && (github.event_name == 'schedule'  && github.repository_owner == 'orcestra-campaign') || (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'orcestra-campaign')"
+    if: "always() && github.repository_owner == 'orcestra-campaign' && (github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main'))"
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/buildbook.yaml
+++ b/.github/workflows/buildbook.yaml
@@ -88,7 +88,7 @@ jobs:
 
   publish:
     needs: build
-    if: "always() && github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'orcestra-campaign')"
+    if: "always() && (github.event_name == 'schedule'  && github.repository_owner == 'orcestra-campaign') || (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'orcestra-campaign')"
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
The old workflow tried to publish the book without building it, which led to a failure of the buildbook resulting in numerous emails. This should fix it by only trying to publish on schedule from the orcestra-campaign repository. 