### PR TITLE
restrict versions in environment.yaml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - healpix
   - icalendar
   - intake-xarray
-  - intake[dataframe]<2.0.0 # since intake 0.6.1 to_dask() doesn't work anymore without the [dataframe] specification due to a missing msgpack dependency
+  - intake>=0.7.0,<2.0.0
   - ipykernel
   - ipywidgets
   - jinja2

--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,7 @@ dependencies:
   - simplekml
   - topojson
   - xarray
-  - zarr>=2.8.3
+  - zarr>=2.8.3,<3
   - pip
   - pip:
     - easygems>=0.0.11

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - geopy
   - healpix
   - icalendar
-  - intake-xarray
+  - intake-xarray<=0.7.0
   - intake>=0.7.0,<2.0.0
   - ipykernel
   - ipywidgets


### PR DESCRIPTION
This PR restricts dependency versions of several dependencies in order to keep our build system happy.

Without this change, intake installation may fail with:
```
intake[dataframe] <2.0.0 * does not exist (perhaps a typo or a missing channel).
```

With intake 0.7.0, the issue requiring dataframe should also be solved.

For zarr, while version 3 provides great improvements, we'll want to wait until some teething problems are solved, before migrating with the entire book.