### PR TITLE
pin jupyter book to version 1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - ipykernel
   - ipywidgets
   - jinja2
-  - jupyter-book
+  - jupyter-book>=1,<2
   - jupyterlab
   - jupytext
   - matplotlib


### PR DESCRIPTION
Jupyter Book version 2 will be based on MyST-MD instead of sphinx. It will supposedly be easy to migrate, but will be a breaking change. By pinning to version 1, we should be able to keep the book building during the transitioning period.