### PR TITLE
Add ORCESTRA Attribute Convention

### DIFF
--- a/orcestra_book/_toc.yml
+++ b/orcestra_book/_toc.yml
@@ -37,6 +37,7 @@ chapters:
     - file: data_concept
     - file: attribute_convention
       title: Attribute Convention
+    - file: data_policy
 - file: examples
   sections:
     - file: halo_flight_segmentation

--- a/orcestra_book/_toc.yml
+++ b/orcestra_book/_toc.yml
@@ -42,7 +42,7 @@ chapters:
 - file: how_to
   sections:
     - file: halo_flight_segmentation
-      title: Segment a flight
+      title: Flight segmentation
     - file: hera5
       title: ERA5 data
     - file: water_vapour_overview

--- a/orcestra_book/_toc.yml
+++ b/orcestra_book/_toc.yml
@@ -34,6 +34,11 @@ chapters:
       title: Flight plan docs
 - file: data
   sections:
+    - file: data_concept
+    - file: attribute_convention
+      title: Attribute Convention
+- file: examples
+  sections:
     - file: halo_flight_segmentation
       title: Ex 1 - Segment a flight
     - file: hera5

--- a/orcestra_book/_toc.yml
+++ b/orcestra_book/_toc.yml
@@ -41,19 +41,19 @@ chapters:
 - file: examples
   sections:
     - file: halo_flight_segmentation
-      title: Ex 1 - Segment a flight
+      title: Segment a flight
     - file: hera5
-      title: Ex 2 - ERA5 data
+      title: ERA5 data
     - file: water_vapour_overview
-      title: Ex 3 - Water vapour structure
+      title: Water vapour structure
     - file: temperature_example
-      title: Ex 4 - Temperature comparison
+      title: Temperature comparison
     - file: iwv_comparison
-      title: Ex 5 - IWV comparison
+      title: IWV comparison
     - file: hifs
-      title: Ex 6 - IFS forecasts
+      title: IFS forecasts
     - file: ctd
-      title: Ex 7 - CTD measurements
+      title: CTD measurements
 - file: blog
 - file: coordination
 - file: faq

--- a/orcestra_book/_toc.yml
+++ b/orcestra_book/_toc.yml
@@ -35,6 +35,7 @@ chapters:
 - file: data
   sections:
     - file: data_concept
+    - file: ipfs
     - file: attribute_convention
       title: Attribute Convention
     - file: data_policy

--- a/orcestra_book/_toc.yml
+++ b/orcestra_book/_toc.yml
@@ -39,7 +39,7 @@ chapters:
     - file: attribute_convention
       title: Attribute Convention
     - file: data_policy
-- file: examples
+- file: how_to
   sections:
     - file: halo_flight_segmentation
       title: Segment a flight

--- a/orcestra_book/attribute_convention.md
+++ b/orcestra_book/attribute_convention.md
@@ -1,0 +1,50 @@
+# Attribute Convention for ORCESTRA
+
+## Goals
+
+The goal of this convention is to define a minimal set of global attributes for datasets to provide the following functionalities:
+
+* Automatically retrieve contact information for any dataset
+* Create a summary table with all datasets and some key metadata
+
+## Global attributes
+
+Key | Value
+--- | ---
+`title` | Short phrase or sentence describing the dataset
+`summary` | Paragraph describing the dataset
+`creator_name` | Comma-separated list of names
+`creator_email` | Comma-separated list of emails
+`project` | Comma-separated list of projects (see below)
+`platform` | Name of the platform that supported the sensor (see below)
+`source` | Method of production of the original data (e.g. "radar", "radiometer", "CTD")
+`history` | Audit trail for modifications to the original data
+`license` | [SPDX-ID](https://spdx.org/licenses/)
+`references` | Comma-separated list of URL/DOI to extended information <br/>Published or web-based references that describe the data or methods used to produce it.
+`keywords` | Comma-separated list of keywords
+
+Undefined attributes **should not** be set.
+
+For additional metadata we encourage to follow [CF](https://cfconventions.org) and [ACDD](https://wiki.esipfed.org/Attribute_Convention_for_Data_Discovery_1-3) conventions
+
+## Valid `project` values
+
+* `ORCESTRA`
+* `BOW-TIE`
+* `CELLO`
+* `CLARINET`
+* `MAESTRO`
+* `PERCUSION`
+* `PICCOLO`
+* `SCORE`
+* `STRINQS`
+
+## Valid `platform` values
+
+* `EarthCARE`
+* `HALO`
+* `ATR-42`
+* `INCAS KingAir`
+* `BCO`
+* `CVAO`
+* `RV METEOR`

--- a/orcestra_book/data.md
+++ b/orcestra_book/data.md
@@ -1,27 +1,5 @@
 # Data
 
-The ORCESTRA data is stored via an InterPlanetary File System [(IPFS)](https://docs.ipfs.tech/concepts/what-is-ipfs/). The latest dataset is available at `/ipns/latest.orcestra-campaign.org`.
-
-For a first overview and to browse the data, checkout the public gateway: **https://ipfs.io/ipns/latest.orcestra-campaign.org**.
-
-It is recommended to use your own [local gateway](https://docs.ipfs.tech/concepts/ipfs-gateway/#gateway-providers) for an accelerated access.
-
-
-```{dropdown}  More about IPFS
-
-> IPFS is a modular suite of protocols for organizing and transferring data, designed from the ground up with the principles of content addressing and peer-to-peer networking. Because IPFS is open-source, there are multiple implementations of IPFS. While IPFS has more than one use case, its main use case is for publishing data (files, directories, websites, etc.) in a decentralised fashion. [(*Source*)](https://docs.ipfs.tech/concepts/what-is-ipfs/#defining-ipfs)
-
-References:
-- [IPFS documentation](https://docs.ipfs.tech)
-- [IPFS@ORCESTRA](https://orcestra-campaign.github.io/ipfs_intro/#/title-slide)
-
-```
-
-If you like to find out more about our **data concept**, have a look [here](data_concept.md).
-
-
-
-
 ## Datasets
 
 ```{admonition} Available data

--- a/orcestra_book/data.md
+++ b/orcestra_book/data.md
@@ -40,11 +40,6 @@ If you like to find out more about our **data concept**, have a look [here](data
 💡 Do you want to [contribute](https://github.com/orcestra-campaign/book/blob/main/CONTRIBUTING.md) or did you figure out that your data is missing? Feel free to [open an issue](https://github.com/orcestra-campaign/book/issues/new) or [contact us](mailto:yuting.wu@mpimet.mpg.de).
 
 
-### Working with the data
-
-If you like to work with the data, feel free to have a look into the script examples (marked with *Ex [NN]*) listed in the left column below the data section. Also feel free to contribute with your own script to this website.
-
-
 ### Supporting data
 #### Numerical simulations - Limited area model
 

--- a/orcestra_book/data.md
+++ b/orcestra_book/data.md
@@ -53,20 +53,3 @@ Visualisations of individual variables for each day are given [here](lam.md). An
 </video>
 
 Tracks of ATR-42, HALO and RV METEOR simulated with the Limited Area Model throughout the campaign (*by R. Fievet*).
-
-
----
-
-
-## Data Policy
-
-ORCESTRA encourages free use and access to its data and relies on the integrity of the scientific community to ensure that this open data policy does not diminish the contributions of those who collected these data.
-
-ORCESTRA data are a product of the collective efforts of various independent research groups, whose efforts have often benefited from financial support by external funding agencies. The data represents years of work in developing, certifying, and operating instruments, often tied to specific research or Ph.D. projects. We ask users to respect the priority of the data collectors by coordinating their use of ORCESTRA data with the Principal Investigators (PIs) responsible for the data collection, and by clearly acknowledging the source of the data used in all publications and presentations.
-
-For publications using ORCESTRA data, please include this acknowledgement:
-
-> "ORCESTRA was made possible thanks to the support of the Max Planck Society (MPG), the European Research Counceil through Grant No. (XXX), the German Research Foundation (DFG), the German Aerospace Center (DLR), the German Federal Ministry for Education and Research (BMBF), the French National Centre for Scientific Research (CNRS), the European Space Agency (ESA), and the US National Science Foundation (NSF), through Grant No. YYY".  [The specific data used in this study was made available by instution/person XY thanks with partial support from agency XYZ]
-
-To ensure the recognition of contributions to the data collection, while promoting its open and respectful use.
-

--- a/orcestra_book/data_concept.md
+++ b/orcestra_book/data_concept.md
@@ -1,7 +1,3 @@
----
-orphan: true
----
-
 # Data Concept
 
 We like to see ORCESTRA as **our common** field campaign.

--- a/orcestra_book/data_policy.md
+++ b/orcestra_book/data_policy.md
@@ -1,7 +1,3 @@
----
-orphan: true
----
-
 # Data Policy
 
 ORCESTRA encourages free use and access to its data and relies on the integrity of the scientific community to ensure that this open data policy does not diminish the contributions of those who collected these data.

--- a/orcestra_book/examples.md
+++ b/orcestra_book/examples.md
@@ -1,0 +1,3 @@
+# Examples
+
+If you would like to work with the data, feel free to have a look into the script examples listed in the left column below the "Examples" section. Also feel free to contribute your own examples to this website.

--- a/orcestra_book/examples.md
+++ b/orcestra_book/examples.md
@@ -1,3 +1,0 @@
-# Examples
-
-If you would like to work with the data, feel free to have a look into the script examples listed in the left column below the "Examples" section. Also feel free to contribute your own examples to this website.

--- a/orcestra_book/how_to.md
+++ b/orcestra_book/how_to.md
@@ -1,0 +1,3 @@
+# How to
+
+If you would like to work with the data, feel free to have a look into the script examples listed in the left column below the "How to" section. Also feel free to contribute your own examples to this website.

--- a/orcestra_book/ipfs.md
+++ b/orcestra_book/ipfs.md
@@ -1,0 +1,20 @@
+# IPFS
+
+The ORCESTRA data is stored via the InterPlanetary File System [(IPFS)](https://docs.ipfs.tech/concepts/what-is-ipfs/). The latest version of the dataset is available at `/ipns/latest.orcestra-campaign.org`.
+
+For a first overview, and to browse the data, checkout the public gateway: **https://ipfs.io/ipns/latest.orcestra-campaign.org**.
+
+It is recommended to use your own [local gateway](https://docs.ipfs.tech/concepts/ipfs-gateway/#gateway-providers) for an accelerated access.
+
+```{admonition}  More about IPFS
+:class: tip
+
+> IPFS is a modular suite of protocols for organizing and transferring data, designed from the ground up with the principles of content addressing and peer-to-peer networking. Because IPFS is open-source, there are multiple implementations of IPFS. While IPFS has more than one use case, its main use case is for publishing data (files, directories, websites, etc.) in a decentralised fashion. [(*Source*)](https://docs.ipfs.tech/concepts/what-is-ipfs/#defining-ipfs)
+
+References:
+- [IPFS documentation](https://docs.ipfs.tech)
+- [IPFS@ORCESTRA](https://orcestra-campaign.github.io/ipfs_intro/#/title-slide)
+
+```
+
+If you like to find out more about our **data concept** and how it relates to IPFS, have a look [here](data_concept.md).


### PR DESCRIPTION
This PR
* adds the initial version of the ORCESTRA Attribute Convention for datasets
* introduces separate "Data" and "Examples" chapters
* adds a dedicated "IPFS" document