### PR TITLE
Extend Attribute Convention

### DIFF
--- a/orcestra_book/attribute_convention.md
+++ b/orcestra_book/attribute_convention.md
@@ -40,6 +40,7 @@ Key | Value
 `institution` | Institution responsible for the dataset
 `instrument` | Instrument used to measure the data (may be set in addition to `source`)
 `creator_id` | Comma-separated list of identifiers (e.g. ORCID)
+`Conventions` | A comma-separated list of the conventions that are followed by the dataset, e.g., 'ACDD-1.3, CF-1.12'.
 
 ## Valid `project` values
 

--- a/orcestra_book/attribute_convention.md
+++ b/orcestra_book/attribute_convention.md
@@ -16,17 +16,24 @@ The required attributes are essential for the [ORCESTRA Data Browser](https://br
 
 If an attribute is undefined, it is recommended not to set it instead of using empty strings.
 
+### Required
+
 Key | Value
 --- | ---
 `title` | Short phrase or sentence describing the dataset
 `summary` | Paragraph describing the dataset
 `creator_name` | Comma-separated list of names
 `creator_email` | Comma-separated list of emails
+`license` | [SPDX-ID](https://spdx.org/licenses/)
+
+### Recommended
+
+Key | Value
+--- | ---
 `project` | Comma-separated list of projects (see below)
 `platform` | Name of the platform that supported the sensor (see below)
 `source` | Method of production of the original data (e.g. "radar", "radiometer", "CTD")
 `history` | Audit trail for modifications to the original data
-`license` | [SPDX-ID](https://spdx.org/licenses/)
 `references` | Comma-separated list of URL/DOI to extended information <br/>Published or web-based references that describe the data or methods used to produce it.
 `keywords` | Comma-separated list of keywords
 

--- a/orcestra_book/attribute_convention.md
+++ b/orcestra_book/attribute_convention.md
@@ -36,7 +36,7 @@ Key | Value
 `history` | Audit trail for modifications to the original data
 `references` | Comma-separated list of URL/DOI to extended information <br/>Published or web-based references that describe the data or methods used to produce it.
 `keywords` | Comma-separated list of keywords
-`processing_level` | Processing level of the dataset (cf. eg. [NASA](https://www.earthdata.nasa.gov/learn/earth-observation-data-basics/data-processing-levels))
+`processing_level` | A textual description of the processing (or quality control) level of the data.
 `institution` | Institution responsible for the dataset
 `instrument` | Institute used to measure the data (may be set in addition to `source`)
 `creator_id` | Comma-separated list of identifiers (e.g. ORCID)

--- a/orcestra_book/attribute_convention.md
+++ b/orcestra_book/attribute_convention.md
@@ -11,6 +11,11 @@ For additional metadata not covered by this convention we recommend following th
 
 ## Global attributes
 
+The following section lists a selection of required and recommended global attributes for datasets.
+The required attributes are essential for the [ORCESTRA Data Browser](https://browser.orcestra-campaign.org) to render proper landing pages.
+
+If an attribute is undefined, it is recommended not to set it instead of using empty strings.
+
 Key | Value
 --- | ---
 `title` | Short phrase or sentence describing the dataset
@@ -24,8 +29,6 @@ Key | Value
 `license` | [SPDX-ID](https://spdx.org/licenses/)
 `references` | Comma-separated list of URL/DOI to extended information <br/>Published or web-based references that describe the data or methods used to produce it.
 `keywords` | Comma-separated list of keywords
-
-Undefined attributes **should not** be set.
 
 
 ## Valid `project` values

--- a/orcestra_book/attribute_convention.md
+++ b/orcestra_book/attribute_convention.md
@@ -36,7 +36,10 @@ Key | Value
 `history` | Audit trail for modifications to the original data
 `references` | Comma-separated list of URL/DOI to extended information <br/>Published or web-based references that describe the data or methods used to produce it.
 `keywords` | Comma-separated list of keywords
-
+`processing_level` | Processing level of the dataset (cf. eg. [NASA](https://www.earthdata.nasa.gov/learn/earth-observation-data-basics/data-processing-levels))
+`institution` | Institution responsible for the dataset
+`instrument` | Institute used to measure the data (may be set in addition to `source`)
+`creator_id` | Comma-separated list of identifiers (e.g. ORCID)
 
 ## Valid `project` values
 

--- a/orcestra_book/attribute_convention.md
+++ b/orcestra_book/attribute_convention.md
@@ -38,7 +38,7 @@ Key | Value
 `keywords` | Comma-separated list of keywords
 `processing_level` | A textual description of the processing (or quality control) level of the data.
 `institution` | Institution responsible for the dataset
-`instrument` | Institute used to measure the data (may be set in addition to `source`)
+`instrument` | Instrument used to measure the data (may be set in addition to `source`)
 `creator_id` | Comma-separated list of identifiers (e.g. ORCID)
 
 ## Valid `project` values

--- a/orcestra_book/attribute_convention.md
+++ b/orcestra_book/attribute_convention.md
@@ -7,6 +7,8 @@ The goal of this convention is to define a minimal set of global attributes for 
 * Automatically retrieve contact information for any dataset
 * Create a summary table with all datasets and some key metadata
 
+For additional metadata not covered by this convention we recommend following the [CF](https://cfconventions.org) and [ACDD](https://wiki.esipfed.org/Attribute_Convention_for_Data_Discovery_1-3) conventions.
+
 ## Global attributes
 
 Key | Value
@@ -25,7 +27,6 @@ Key | Value
 
 Undefined attributes **should not** be set.
 
-For additional metadata we encourage to follow [CF](https://cfconventions.org) and [ACDD](https://wiki.esipfed.org/Attribute_Convention_for_Data_Discovery_1-3) conventions
 
 ## Valid `project` values
 


### PR DESCRIPTION
This PR extends the Attribute Convention

* Add additional metadata from discussion with colleagues from DKRZ
* Distinguish required and recommended attributes

There is one open point to discuss: while separating "required" and "recommended" attributes I took the proper rendering of the Data Browser in its current implementation as reference. Therefore, many of the existing attributes moved to the recommended section.
I think this is fine and actually closer to the truth, but I am also happy to keepn them as required and only add the new ones as recommended.