### PR TITLE
Extend attribute convention

### DIFF
--- a/orcestra_book/attribute_convention.md
+++ b/orcestra_book/attribute_convention.md
@@ -43,30 +43,6 @@ Key | Value
 `creator_id` | Comma-separated list of identifiers (e.g. ORCID)
 `Conventions` | A comma-separated list of the conventions that are followed by the dataset, e.g., 'ACDD-1.3, CF-1.12'.
 
-## Valid `project` values
-
-* `ORCESTRA`
-* `BOW-TIE`
-* `CELLO`
-* `CLARINET`
-* `MAESTRO`
-* `PERCUSION`
-* `PICCOLO`
-* `SCORE`
-* `STRINQS`
-
-## Valid `platform` values
-
-* `EarthCARE`
-* `HALO`
-* `ATR-42`
-* `INCAS KingAir`
-* `BCO`
-* `CVAO`
-* `RV METEOR`
-* `INMG`
-* `MSG`
-
 ## Annotating datasets without native metadata
 
 Our attribute convention is based on the use of global attributes.
@@ -106,3 +82,14 @@ extent:
   temporal: ["2024-08-09T14:26:37", "2024-09-28T19:30:47"]
   spatial: [-59.45647812, 1.29273319, -19.62099838, 22.03603554]
 ```
+
+
+## Appendix: Controlled Vocabularies
+
+**Project identifiers:**
+
+`ORCESTRA`, `BOW-TIE`, `CELLO`, `CLARINET`, `MAESTRO`, `PERCUSION`, `PICCOLO`, `SCORE`, `STRINQS`
+
+**Platform identifiers:**
+
+`EarthCARE`, `HALO`, `ATR-42`, `INCAS KingAir`, `BCO`, `CVAO`, `RV METEOR`, `INMG`, `MSG`

--- a/orcestra_book/attribute_convention.md
+++ b/orcestra_book/attribute_convention.md
@@ -66,3 +66,43 @@ Key | Value
 * `RV METEOR`
 * `INMG`
 * `MSG`
+
+## Annotating datasets without native metadata
+
+Our attribute convention is based on the use of global attributes.
+However, not all data formats support metadata natively (e.g., CSV, PDF).
+While we strongly recommend converting data to formats that support attributes, a fallback mechanism is provided for externally annotating data of any format.
+
+Each directory containing a file named `dataset_meta.yaml` is considered a dataset.
+This [YAML](https://yaml.org/spec/) file **must** include an `attributes` block that defines the dataset’s global attributes.
+All attributes **must** comply with the ORCESTRA Attribute Convention.
+
+The file **may** also include an optional `extent` block, used to provide information that would otherwise be derived from dataset coordinates.
+Currently, the `extent` block supports the following keys:
+
+Key | Type | Description
+--- | --- | ---
+`temporal` | [string] | Temporal extent in [ISO 8601 format](https://www.iso.org/iso-8601-date-and-time-format.html)
+`spatial` | [float] | Geospatial extent defined by a [GeoJSON Bounding Box](https://datatracker.ietf.org/doc/html/rfc7946#section-5)
+
+**Example:**
+
+```yaml
+attributes:
+  title: BEACH dropsonde dataset (Level 3)
+  summary: This dataset is the Level 3 BEACH dataset. It contains quality controlled
+    dropsonde data from the ORCESTRA field campaign with a common altitude dimension.
+  creator_name: Helene Gloeckner, Theresa Mieslinger, Nina Robbins
+  creator_email: helene.gloeckner@mpimet.mpg.de, theresa.mieslinger@mpimet.mpg.de, nina.robbins@mpimet.mpg.de
+  license: CC-BY-4.0
+  featureType: trajectoryProfile
+  history: Level 1 ASPEN processing with Aspen V4.0.4
+  keywords: ORCESTRA, BEACH, Sounding, Dropsondes, Atmospheric Profiles
+  platform: HALO
+  project: ORCESTRA, PERCUSION, MAESTRO
+  references: https://github.com/atmdrops/pydropsonde
+  source: dropsondes
+extent:
+  temporal: ["2024-08-09T14:26:37", "2024-09-28T19:30:47"]
+  spatial: [-59.45647812, 1.29273319, -19.62099838, 22.03603554]
+```


### PR DESCRIPTION
This PR:
* adds that describes how to annotate datasets without attributes using a `dataset_meta.yaml`
* moves the controlled vocabulary to an appendix at the end of the page

These changes are based on a discussion in https://github.com/orcestra-campaign/ipfsui/issues/63